### PR TITLE
Budgets Page + getEffectiveBudget() (mock-first)

### DIFF
--- a/frontend/src/__tests__/budget.test.ts
+++ b/frontend/src/__tests__/budget.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { getEffectiveBudget } from "../lib/budget";
+import type { BudgetAssignment } from "../types";
+
+function makeAssignment(
+  id: string,
+  budgetId: string,
+  effectiveFrom: string,
+  note: string | null = null,
+): BudgetAssignment {
+  return { id, budgetId, effectiveFrom, note };
+}
+
+describe("getEffectiveBudget — no assignments", () => {
+  it("returns null when the list is empty", () => {
+    expect(getEffectiveBudget([], "2025-03")).toBeNull();
+  });
+});
+
+describe("getEffectiveBudget — single assignment", () => {
+  it("returns the assignment when effectiveFrom equals month", () => {
+    const a = makeAssignment("a1", "b1", "2025-03");
+    expect(getEffectiveBudget([a], "2025-03")).toEqual(a);
+  });
+
+  it("returns the assignment when effectiveFrom is before month", () => {
+    const a = makeAssignment("a1", "b1", "2025-01");
+    expect(getEffectiveBudget([a], "2025-03")).toEqual(a);
+  });
+
+  it("returns null when the single assignment is future-dated", () => {
+    const a = makeAssignment("a1", "b1", "2025-06");
+    expect(getEffectiveBudget([a], "2025-03")).toBeNull();
+  });
+});
+
+describe("getEffectiveBudget — exact effectiveFrom match", () => {
+  it("prefers the exact-match assignment over an earlier one", () => {
+    const earlier = makeAssignment("a1", "b1", "2025-01");
+    const exact = makeAssignment("a2", "b2", "2025-03");
+    expect(getEffectiveBudget([earlier, exact], "2025-03")).toEqual(exact);
+  });
+});
+
+describe("getEffectiveBudget — multiple assignments", () => {
+  const assignments: BudgetAssignment[] = [
+    makeAssignment("a1", "b1", "2024-10"),
+    makeAssignment("a2", "b2", "2025-01"),
+    makeAssignment("a3", "b1", "2024-12"),
+  ];
+
+  it("returns the most recent assignment that is ≤ month", () => {
+    // For 2025-03: eligible are 2024-10, 2025-01, 2024-12 → most recent is 2025-01
+    expect(getEffectiveBudget(assignments, "2025-03")).toEqual(assignments[1]);
+  });
+
+  it("respects the month boundary — returns latest eligible before the query month", () => {
+    // For 2024-11: eligible are 2024-10 only (2024-12 and 2025-01 are future)
+    expect(getEffectiveBudget(assignments, "2024-11")).toEqual(assignments[0]);
+  });
+
+  it("handles exact month matching with multiple candidates", () => {
+    // For 2024-12: eligible are 2024-10 and 2024-12 → most recent is 2024-12
+    expect(getEffectiveBudget(assignments, "2024-12")).toEqual(assignments[2]);
+  });
+});
+
+describe("getEffectiveBudget — future-dated assignments", () => {
+  it("ignores all future-dated assignments", () => {
+    const past = makeAssignment("a1", "b1", "2025-01");
+    const future1 = makeAssignment("a2", "b2", "2025-06");
+    const future2 = makeAssignment("a3", "b3", "2026-01");
+    expect(getEffectiveBudget([past, future1, future2], "2025-03")).toEqual(past);
+  });
+
+  it("returns null when all assignments are in the future", () => {
+    const future1 = makeAssignment("a1", "b1", "2025-06");
+    const future2 = makeAssignment("a2", "b2", "2025-12");
+    expect(getEffectiveBudget([future1, future2], "2025-03")).toBeNull();
+  });
+});
+
+describe("getEffectiveBudget — order independence", () => {
+  it("returns the same result regardless of input order", () => {
+    const a1 = makeAssignment("a1", "b1", "2024-10");
+    const a2 = makeAssignment("a2", "b2", "2025-01");
+    const a3 = makeAssignment("a3", "b1", "2024-12");
+
+    const result1 = getEffectiveBudget([a1, a2, a3], "2025-03");
+    const result2 = getEffectiveBudget([a3, a1, a2], "2025-03");
+    const result3 = getEffectiveBudget([a2, a3, a1], "2025-03");
+
+    expect(result1).toEqual(result2);
+    expect(result1).toEqual(result3);
+    expect(result1).toEqual(a2);
+  });
+});

--- a/frontend/src/__tests__/fixtures/index.ts
+++ b/frontend/src/__tests__/fixtures/index.ts
@@ -1141,6 +1141,7 @@ export const mockBudgets: Budget[] = [
       "Insurance": 150,
     },
     netGainOrLoss: 3800 - (400 + 150 + 1800 + 100 + 80 + 200 + 150),
+    note: "Base budget for Q4 2024",
   },
   {
     id: "budget-002",
@@ -1156,6 +1157,7 @@ export const mockBudgets: Budget[] = [
       "Services": 75,
     },
     netGainOrLoss: 3800 - (450 + 175 + 1800 + 150 + 100 + 250 + 150 + 75),
+    note: "New Year revision — increased food and health limits",
   },
 ];
 

--- a/frontend/src/api/budgets.ts
+++ b/frontend/src/api/budgets.ts
@@ -28,6 +28,7 @@ export async function createBudget(
   if (USE_MOCK) {
     const budget: Budget = {
       ...payload,
+      note: payload.note ?? null,
       id: `budget-${Date.now()}`,
       dateCreated: new Date().toISOString(),
     };
@@ -76,8 +77,8 @@ export async function deleteBudget(id: string): Promise<void> {
     const idx = mutableBudgets.findIndex((b) => b.id === id);
     if (idx === -1) throw new Error(`Budget ${id} not found`);
     mutableBudgets = mutableBudgets.filter((b) => b.id !== id);
-    // Also remove any assignments referencing this budget
-    mutableAssignments = mutableAssignments.filter((a) => a.budgetId !== id);
+    // Assignments are NOT cascade-deleted — the caller must reassign covered
+    // months before deleting a budget that has assignments.
     return;
   }
 

--- a/frontend/src/api/budgets.ts
+++ b/frontend/src/api/budgets.ts
@@ -1,0 +1,141 @@
+import type { Budget, BudgetAssignment } from "../types";
+import { mockBudgets, mockBudgetAssignments } from "../__tests__/fixtures";
+
+const USE_MOCK = true;
+
+// In-memory mutable copies for mock CRUD operations
+let mutableBudgets: Budget[] = [...mockBudgets];
+let mutableAssignments: BudgetAssignment[] = [...mockBudgetAssignments];
+
+// ─── Budgets ──────────────────────────────────────────────────────────────────
+
+export async function getBudgets(): Promise<Budget[]> {
+  if (USE_MOCK) {
+    return [...mutableBudgets];
+  }
+
+  // Real fetch stub — uncomment and remove mock block above when FastAPI is ready
+  // const res = await fetch("/api/budgets");
+  // if (!res.ok) throw new Error("Failed to fetch budgets");
+  // const json = await res.json();
+  // return json.data as Budget[];
+  throw new Error("Real API not implemented");
+}
+
+export async function createBudget(
+  payload: Omit<Budget, "id" | "dateCreated">,
+): Promise<Budget> {
+  if (USE_MOCK) {
+    const budget: Budget = {
+      ...payload,
+      id: `budget-${Date.now()}`,
+      dateCreated: new Date().toISOString(),
+    };
+    mutableBudgets = [...mutableBudgets, budget];
+    return budget;
+  }
+
+  // Real fetch stub — uncomment and remove mock block above when FastAPI is ready
+  // const res = await fetch("/api/budgets", {
+  //   method: "POST",
+  //   headers: { "Content-Type": "application/json" },
+  //   body: JSON.stringify(payload),
+  // });
+  // if (!res.ok) throw new Error("Failed to create budget");
+  // const json = await res.json();
+  // return json.data as Budget;
+  throw new Error("Real API not implemented");
+}
+
+export async function updateBudget(
+  id: string,
+  payload: Partial<Omit<Budget, "id" | "dateCreated">>,
+): Promise<Budget> {
+  if (USE_MOCK) {
+    const idx = mutableBudgets.findIndex((b) => b.id === id);
+    if (idx === -1) throw new Error(`Budget ${id} not found`);
+    const updated: Budget = { ...mutableBudgets[idx], ...payload };
+    mutableBudgets = mutableBudgets.map((b) => (b.id === id ? updated : b));
+    return updated;
+  }
+
+  // Real fetch stub — uncomment and remove mock block above when FastAPI is ready
+  // const res = await fetch(`/api/budgets/${id}`, {
+  //   method: "PUT",
+  //   headers: { "Content-Type": "application/json" },
+  //   body: JSON.stringify(payload),
+  // });
+  // if (!res.ok) throw new Error("Failed to update budget");
+  // const json = await res.json();
+  // return json.data as Budget;
+  throw new Error("Real API not implemented");
+}
+
+export async function deleteBudget(id: string): Promise<void> {
+  if (USE_MOCK) {
+    const idx = mutableBudgets.findIndex((b) => b.id === id);
+    if (idx === -1) throw new Error(`Budget ${id} not found`);
+    mutableBudgets = mutableBudgets.filter((b) => b.id !== id);
+    // Also remove any assignments referencing this budget
+    mutableAssignments = mutableAssignments.filter((a) => a.budgetId !== id);
+    return;
+  }
+
+  // Real fetch stub — uncomment and remove mock block above when FastAPI is ready
+  // const res = await fetch(`/api/budgets/${id}`, { method: "DELETE" });
+  // if (!res.ok) throw new Error("Failed to delete budget");
+  throw new Error("Real API not implemented");
+}
+
+// ─── Budget Assignments ───────────────────────────────────────────────────────
+
+export async function getBudgetAssignments(): Promise<BudgetAssignment[]> {
+  if (USE_MOCK) {
+    return [...mutableAssignments];
+  }
+
+  // Real fetch stub — uncomment and remove mock block above when FastAPI is ready
+  // const res = await fetch("/api/budgets/assignments");
+  // if (!res.ok) throw new Error("Failed to fetch budget assignments");
+  // const json = await res.json();
+  // return json.data as BudgetAssignment[];
+  throw new Error("Real API not implemented");
+}
+
+export async function createBudgetAssignment(
+  payload: Omit<BudgetAssignment, "id">,
+): Promise<BudgetAssignment> {
+  if (USE_MOCK) {
+    const assignment: BudgetAssignment = {
+      ...payload,
+      id: `assign-${Date.now()}`,
+    };
+    mutableAssignments = [...mutableAssignments, assignment];
+    return assignment;
+  }
+
+  // Real fetch stub — uncomment and remove mock block above when FastAPI is ready
+  // const res = await fetch("/api/budgets/assignments", {
+  //   method: "POST",
+  //   headers: { "Content-Type": "application/json" },
+  //   body: JSON.stringify(payload),
+  // });
+  // if (!res.ok) throw new Error("Failed to create budget assignment");
+  // const json = await res.json();
+  // return json.data as BudgetAssignment;
+  throw new Error("Real API not implemented");
+}
+
+export async function deleteBudgetAssignment(id: string): Promise<void> {
+  if (USE_MOCK) {
+    const idx = mutableAssignments.findIndex((a) => a.id === id);
+    if (idx === -1) throw new Error(`Assignment ${id} not found`);
+    mutableAssignments = mutableAssignments.filter((a) => a.id !== id);
+    return;
+  }
+
+  // Real fetch stub — uncomment and remove mock block above when FastAPI is ready
+  // const res = await fetch(`/api/budgets/assignments/${id}`, { method: "DELETE" });
+  // if (!res.ok) throw new Error("Failed to delete budget assignment");
+  throw new Error("Real API not implemented");
+}

--- a/frontend/src/api/budgets.ts
+++ b/frontend/src/api/budgets.ts
@@ -107,6 +107,11 @@ export async function createBudgetAssignment(
   payload: Omit<BudgetAssignment, "id">,
 ): Promise<BudgetAssignment> {
   if (USE_MOCK) {
+    // Upsert: replace any existing assignment for the same effectiveFrom month
+    // so that reassigning the current month always takes effect immediately.
+    mutableAssignments = mutableAssignments.filter(
+      (a) => a.effectiveFrom !== payload.effectiveFrom,
+    );
     const assignment: BudgetAssignment = {
       ...payload,
       id: `assign-${Date.now()}`,

--- a/frontend/src/hooks/useBudgets.ts
+++ b/frontend/src/hooks/useBudgets.ts
@@ -1,0 +1,75 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createBudget,
+  createBudgetAssignment,
+  deleteBudget,
+  deleteBudgetAssignment,
+  getBudgetAssignments,
+  getBudgets,
+  updateBudget,
+} from "../api/budgets";
+
+export function useBudgets() {
+  return useQuery({
+    queryKey: ["budgets"],
+    queryFn: getBudgets,
+  });
+}
+
+export function useBudgetAssignments() {
+  return useQuery({
+    queryKey: ["budgets", "assignments"],
+    queryFn: getBudgetAssignments,
+  });
+}
+
+export function useCreateBudget() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createBudget,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+}
+
+export function useUpdateBudget() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: Parameters<typeof updateBudget>[1] }) =>
+      updateBudget(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+}
+
+export function useDeleteBudget() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteBudget,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+}
+
+export function useCreateBudgetAssignment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createBudgetAssignment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+}
+
+export function useDeleteBudgetAssignment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteBudgetAssignment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["budgets"] });
+    },
+  });
+}

--- a/frontend/src/lib/budget.ts
+++ b/frontend/src/lib/budget.ts
@@ -1,6 +1,44 @@
 import type { BudgetAssignment } from "../types";
 
 /**
+ * Returns the assignment period for a given budget.
+ *
+ * @param budgetId    - The budget to look up.
+ * @param assignments - All budget assignments.
+ * @returns `{ from: "YYYY-MM", to: "YYYY-MM" | null }` where `to` is null if
+ *          this budget is still active (no later assignment exists).
+ */
+export function getBudgetPeriod(
+  budgetId: string,
+  assignments: BudgetAssignment[],
+): { from: string; to: string | null } | null {
+  // Find all assignments for this budget, sorted ascending
+  const own = assignments
+    .filter((a) => a.budgetId === budgetId)
+    .sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom));
+
+  if (own.length === 0) return null;
+
+  const from = own[0].effectiveFrom;
+
+  // Find the earliest assignment for a *different* budget that comes after `from`
+  const later = assignments
+    .filter((a) => a.budgetId !== budgetId && a.effectiveFrom > from)
+    .sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom));
+
+  const to = later.length > 0 ? prevMonth(later[0].effectiveFrom) : null;
+
+  return { from, to };
+}
+
+/** Returns the YYYY-MM of the month before the given YYYY-MM string. */
+function prevMonth(yyyyMm: string): string {
+  const [y, m] = yyyyMm.split("-").map(Number);
+  if (m === 1) return `${y - 1}-12`;
+  return `${y}-${String(m - 1).padStart(2, "0")}`;
+}
+
+/**
  * Returns the active BudgetAssignment for a given month.
  *
  * The active assignment is the one with the most recent `effectiveFrom` that

--- a/frontend/src/lib/budget.ts
+++ b/frontend/src/lib/budget.ts
@@ -1,0 +1,24 @@
+import type { BudgetAssignment } from "../types";
+
+/**
+ * Returns the active BudgetAssignment for a given month.
+ *
+ * The active assignment is the one with the most recent `effectiveFrom` that
+ * is less than or equal to `month`. Future-dated assignments (effectiveFrom >
+ * month) are never returned.
+ *
+ * @param assignments - All budget assignments, in any order.
+ * @param month       - The target month in YYYY-MM format.
+ * @returns The effective BudgetAssignment, or null if none applies.
+ */
+export function getEffectiveBudget(
+  assignments: BudgetAssignment[],
+  month: string,
+): BudgetAssignment | null {
+  const eligible = assignments.filter((a) => a.effectiveFrom <= month);
+  if (eligible.length === 0) return null;
+
+  return eligible.reduce((best, curr) =>
+    curr.effectiveFrom > best.effectiveFrom ? curr : best,
+  );
+}

--- a/frontend/src/pages/Budgets.tsx
+++ b/frontend/src/pages/Budgets.tsx
@@ -1,8 +1,672 @@
-export default function Budgets() {
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CATEGORY_MAPPING } from "@/constants/categories";
+import {
+  useBudgetAssignments,
+  useBudgets,
+  useCreateBudget,
+  useCreateBudgetAssignment,
+  useDeleteBudget,
+  useDeleteBudgetAssignment,
+} from "@/hooks/useBudgets";
+import { getEffectiveBudget } from "@/lib/budget";
+import { currentMonth, formatCurrency, formatDate, formatMonth } from "@/lib/formatters";
+import type { Budget, BudgetAssignment } from "@/types";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  AlertCircle,
+  CalendarCheck,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  PlusCircle,
+  RefreshCw,
+  Trash2,
+  Wallet,
+} from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+// ─── Primary spending categories (excludes flow-through categories) ────────────
+
+const SPENDING_CATEGORIES = Object.keys(CATEGORY_MAPPING).filter(
+  (c) => !["Income", "Transfers", "Debt payments", "Investments", "Bank fees"].includes(c),
+);
+
+// ─── Zod schemas ──────────────────────────────────────────────────────────────
+
+const budgetSchema = z.object({
+  categoryLimits: z.record(
+    z.string(),
+    z.number({ error: "Must be a number" }).min(0, "Must be ≥ 0"),
+  ),
+  incomeEstimate: z.number({ error: "Must be a number" }).min(0, "Must be ≥ 0"),
+});
+
+type BudgetFormValues = z.infer<typeof budgetSchema>;
+
+const assignmentSchema = z.object({
+  budgetId: z.string().min(1, "Select a budget"),
+  effectiveFrom: z
+    .string()
+    .regex(/^\d{4}-\d{2}$/, "Must be YYYY-MM format"),
+  note: z.string().max(200, "Max 200 characters").optional(),
+});
+
+type AssignmentFormValues = z.infer<typeof assignmentSchema>;
+
+// ─── Skeleton components ──────────────────────────────────────────────────────
+
+function ActiveBudgetSkeleton() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold">Budgets</h1>
-      <p className="text-muted-foreground mt-1">Budget management coming soon.</p>
+    <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-3 w-40" />
     </div>
-  )
+  );
+}
+
+function BudgetCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  );
+}
+
+// ─── Error card ───────────────────────────────────────────────────────────────
+
+function ErrorCard({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="rounded-xl border border-destructive/40 bg-destructive/5 p-5 flex items-center gap-3">
+      <AlertCircle size={18} className="text-destructive shrink-0" />
+      <p className="text-sm flex-1">{message}</p>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        <RefreshCw size={13} className="mr-1" />
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+// ─── Active budget card ───────────────────────────────────────────────────────
+
+interface ActiveBudgetCardProps {
+  budgets: Budget[];
+  assignments: BudgetAssignment[];
+}
+
+function ActiveBudgetCard({ budgets, assignments }: ActiveBudgetCardProps) {
+  const month = currentMonth();
+  const active = getEffectiveBudget(assignments, month);
+  const budget = active ? budgets.find((b) => b.id === active.budgetId) : null;
+
+  if (!active || !budget) {
+    return (
+      <div className="rounded-xl border border-dashed border-border bg-muted/30 p-5 flex items-center gap-3">
+        <CalendarCheck size={18} className="text-muted-foreground shrink-0" />
+        <p className="text-sm text-muted-foreground">
+          No budget is currently active. Assign a budget below to get started.
+        </p>
+      </div>
+    );
+  }
+
+  const limitTotal = Object.values(budget.categoryLimits).reduce((s, v) => s + v, 0);
+
+  return (
+    <div className="rounded-xl border border-primary/30 bg-primary/5 p-5 space-y-2">
+      <div className="flex items-center gap-2 text-primary">
+        <CheckCircle2 size={16} className="shrink-0" />
+        <span className="text-xs font-medium uppercase tracking-wide">Active budget</span>
+      </div>
+      <div className="flex items-baseline gap-3 flex-wrap">
+        <span className="text-lg font-semibold">
+          Created {formatDate(budget.dateCreated)}
+        </span>
+        <span className="text-sm text-muted-foreground">
+          assigned from {formatMonth(active.effectiveFrom)}
+        </span>
+      </div>
+      <div className="flex gap-6 text-sm text-muted-foreground pt-1">
+        <span>
+          <span className="font-medium text-foreground">{formatCurrency(limitTotal)}</span>{" "}
+          total limits
+        </span>
+        <span>
+          Net:{" "}
+          <span
+            className={
+              budget.netGainOrLoss >= 0
+                ? "font-medium text-green-600 dark:text-green-400"
+                : "font-medium text-destructive"
+            }
+          >
+            {formatCurrency(budget.netGainOrLoss)}
+          </span>
+        </span>
+      </div>
+      {active.note && (
+        <p className="text-xs text-muted-foreground border-t border-border/50 pt-2 mt-2">
+          {active.note}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── Budget card (in list) ────────────────────────────────────────────────────
+
+interface BudgetCardProps {
+  budget: Budget;
+  isActive: boolean;
+  onDelete: (id: string) => void;
+  isDeleting: boolean;
+}
+
+function BudgetCard({ budget, isActive, onDelete, isDeleting }: BudgetCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const limits = Object.entries(budget.categoryLimits);
+
+  return (
+    <div
+      className={`rounded-xl border bg-card p-5 space-y-3 ${
+        isActive ? "border-primary/40" : "border-border"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <Wallet size={15} className="text-muted-foreground" />
+            <span className="text-sm font-medium">
+              Created {formatDate(budget.dateCreated)}
+            </span>
+            {isActive && (
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-primary bg-primary/10 rounded px-1.5 py-0.5">
+                Active
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {limits.length} categor{limits.length === 1 ? "y" : "ies"} ·{" "}
+            Net:{" "}
+            <span
+              className={
+                budget.netGainOrLoss >= 0
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-destructive"
+              }
+            >
+              {formatCurrency(budget.netGainOrLoss)}
+            </span>
+          </p>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-muted-foreground"
+            onClick={() => setExpanded((e) => !e)}
+          >
+            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-destructive hover:text-destructive"
+            onClick={() => onDelete(budget.id)}
+            disabled={isDeleting}
+          >
+            <Trash2 size={14} />
+          </Button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 border-t border-border pt-3 text-sm">
+          {limits.map(([category, limit]) => (
+            <div key={category} className="flex justify-between gap-2">
+              <span className="text-muted-foreground truncate">{category}</span>
+              <span className="font-medium tabular-nums">{formatCurrency(limit)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Create budget form ───────────────────────────────────────────────────────
+
+interface CreateBudgetFormProps {
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+function CreateBudgetForm({ onSuccess, onCancel }: CreateBudgetFormProps) {
+  const { mutate, isPending } = useCreateBudget();
+
+  const defaultValues: BudgetFormValues = {
+    categoryLimits: Object.fromEntries(SPENDING_CATEGORIES.map((c) => [c, 0])),
+    incomeEstimate: 0,
+  };
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<BudgetFormValues>({
+    resolver: zodResolver(budgetSchema),
+    defaultValues,
+  });
+
+  const watched = watch();
+  const totalLimits = SPENDING_CATEGORIES.reduce(
+    (sum, c) => sum + (Number(watched.categoryLimits?.[c]) || 0),
+    0,
+  );
+  const net = (Number(watched.incomeEstimate) || 0) - totalLimits;
+
+  function onSubmit(values: BudgetFormValues) {
+    const income = Number(values.incomeEstimate) || 0;
+    const limits: Record<string, number> = {};
+    for (const [cat, val] of Object.entries(values.categoryLimits)) {
+      const n = Number(val);
+      if (n > 0) limits[cat] = n;
+    }
+    const limitSum = Object.values(limits).reduce((s, v) => s + v, 0);
+    mutate(
+      { categoryLimits: limits, netGainOrLoss: income - limitSum },
+      { onSuccess },
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Monthly income estimate</label>
+        <input
+          type="number"
+          min="0"
+          step="0.01"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          {...register("incomeEstimate", { valueAsNumber: true })}
+        />
+        {errors.incomeEstimate && (
+          <p className="text-xs text-destructive">{errors.incomeEstimate.message}</p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-sm font-medium mb-3">Category spending limits</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
+          {SPENDING_CATEGORIES.map((category) => (
+            <div key={category} className="space-y-1">
+              <label className="text-xs text-muted-foreground">{category}</label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="0"
+                className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                {...register(`categoryLimits.${category}`, { valueAsNumber: true })}
+              />
+              {errors.categoryLimits?.[category] && (
+                <p className="text-xs text-destructive">
+                  {errors.categoryLimits[category]?.message}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Live net calculation */}
+      <div className="rounded-lg border border-border bg-muted/30 px-4 py-3 flex items-center justify-between">
+        <div className="text-sm text-muted-foreground">
+          <span className="text-foreground font-medium">{formatCurrency(Number(watched.incomeEstimate) || 0)}</span>
+          {" income − "}
+          <span className="text-foreground font-medium">{formatCurrency(totalLimits)}</span>
+          {" limits"}
+        </div>
+        <div className="text-sm font-semibold">
+          Net:{" "}
+          <span className={net >= 0 ? "text-green-600 dark:text-green-400" : "text-destructive"}>
+            {formatCurrency(net)}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving…" : "Create budget"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// ─── Budget assignment form ───────────────────────────────────────────────────
+
+interface AssignBudgetFormProps {
+  budgets: Budget[];
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+function AssignBudgetForm({ budgets, onSuccess, onCancel }: AssignBudgetFormProps) {
+  const { mutate, isPending } = useCreateBudgetAssignment();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<AssignmentFormValues>({
+    resolver: zodResolver(assignmentSchema),
+    defaultValues: { budgetId: "", effectiveFrom: currentMonth(), note: "" },
+  });
+
+  function onSubmit(values: AssignmentFormValues) {
+    mutate(
+      {
+        budgetId: values.budgetId,
+        effectiveFrom: values.effectiveFrom,
+        note: values.note || null,
+      },
+      { onSuccess },
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Budget</label>
+        <select
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          {...register("budgetId")}
+        >
+          <option value="">Select a budget…</option>
+          {budgets.map((b) => (
+            <option key={b.id} value={b.id}>
+              Created {formatDate(b.dateCreated)} — Net {formatCurrency(b.netGainOrLoss)}
+            </option>
+          ))}
+        </select>
+        {errors.budgetId && (
+          <p className="text-xs text-destructive">{errors.budgetId.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Effective from (YYYY-MM)</label>
+        <input
+          type="text"
+          placeholder="2025-01"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          {...register("effectiveFrom")}
+        />
+        {errors.effectiveFrom && (
+          <p className="text-xs text-destructive">{errors.effectiveFrom.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Note (optional)</label>
+        <input
+          type="text"
+          placeholder="e.g. New Year revision"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          {...register("note")}
+        />
+        {errors.note && (
+          <p className="text-xs text-destructive">{errors.note.message}</p>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={isPending}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Assigning…" : "Assign budget"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// ─── Assignment history list ──────────────────────────────────────────────────
+
+interface AssignmentHistoryProps {
+  assignments: BudgetAssignment[];
+  budgets: Budget[];
+  onDelete: (id: string) => void;
+  isDeleting: boolean;
+}
+
+function AssignmentHistory({
+  assignments,
+  budgets,
+  onDelete,
+  isDeleting,
+}: AssignmentHistoryProps) {
+  const sorted = [...assignments].sort((a, b) =>
+    b.effectiveFrom.localeCompare(a.effectiveFrom),
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-2">
+        No assignments yet. Assign a budget above to start.
+      </p>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-border rounded-xl border border-border overflow-hidden">
+      {sorted.map((a) => {
+        const budget = budgets.find((b) => b.id === a.budgetId);
+        return (
+          <div key={a.id} className="flex items-center justify-between gap-4 px-4 py-3 bg-card">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-sm font-medium">{formatMonth(a.effectiveFrom)}</span>
+                {budget && (
+                  <span className="text-xs text-muted-foreground">
+                    Budget created {formatDate(budget.dateCreated)} · Net{" "}
+                    <span
+                      className={
+                        budget.netGainOrLoss >= 0
+                          ? "text-green-600 dark:text-green-400"
+                          : "text-destructive"
+                      }
+                    >
+                      {formatCurrency(budget.netGainOrLoss)}
+                    </span>
+                  </span>
+                )}
+              </div>
+              {a.note && (
+                <p className="text-xs text-muted-foreground mt-0.5 truncate">{a.note}</p>
+              )}
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-destructive hover:text-destructive shrink-0"
+              onClick={() => onDelete(a.id)}
+              disabled={isDeleting}
+            >
+              <Trash2 size={14} />
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function Budgets() {
+  const {
+    data: budgets,
+    isLoading: loadingBudgets,
+    isError: errorBudgets,
+    refetch: refetchBudgets,
+  } = useBudgets();
+
+  const {
+    data: assignments,
+    isLoading: loadingAssignments,
+    isError: errorAssignments,
+    refetch: refetchAssignments,
+  } = useBudgetAssignments();
+
+  const { mutate: deleteBudget, isPending: deletingBudget } = useDeleteBudget();
+  const { mutate: deleteAssignment, isPending: deletingAssignment } =
+    useDeleteBudgetAssignment();
+
+  const [showCreateBudget, setShowCreateBudget] = useState(false);
+  const [showAssignForm, setShowAssignForm] = useState(false);
+
+  const isLoading = loadingBudgets || loadingAssignments;
+  const isError = errorBudgets || errorAssignments;
+
+  const activeAssignment =
+    budgets && assignments
+      ? getEffectiveBudget(assignments, currentMonth())
+      : null;
+
+  return (
+    <div className="p-6 space-y-8 max-w-4xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-semibold">Budgets</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Manage budgets and track which one is active each month.
+        </p>
+      </div>
+
+      {isError && (
+        <ErrorCard
+          message="Failed to load budget data."
+          onRetry={() => {
+            refetchBudgets();
+            refetchAssignments();
+          }}
+        />
+      )}
+
+      {/* ── Active budget ── */}
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold">Active budget</h2>
+        {isLoading ? (
+          <ActiveBudgetSkeleton />
+        ) : (
+          <ActiveBudgetCard
+            budgets={budgets ?? []}
+            assignments={assignments ?? []}
+          />
+        )}
+      </section>
+
+      {/* ── Budget list ── */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-base font-semibold">Budgets</h2>
+          {!showCreateBudget && (
+            <Button size="sm" onClick={() => setShowCreateBudget(true)}>
+              <PlusCircle size={14} className="mr-1.5" />
+              New budget
+            </Button>
+          )}
+        </div>
+
+        {showCreateBudget && (
+          <div className="rounded-xl border border-border bg-card p-5">
+            <p className="text-sm font-medium mb-4">Create new budget</p>
+            <CreateBudgetForm
+              onSuccess={() => setShowCreateBudget(false)}
+              onCancel={() => setShowCreateBudget(false)}
+            />
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="space-y-3">
+            <BudgetCardSkeleton />
+            <BudgetCardSkeleton />
+          </div>
+        ) : (budgets ?? []).length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            No budgets yet. Create one above.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {(budgets ?? []).map((b) => (
+              <BudgetCard
+                key={b.id}
+                budget={b}
+                isActive={activeAssignment?.budgetId === b.id}
+                onDelete={deleteBudget}
+                isDeleting={deletingBudget}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Assignment ── */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-base font-semibold">Assignment history</h2>
+          {!showAssignForm && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setShowAssignForm(true)}
+              disabled={(budgets ?? []).length === 0}
+            >
+              <CalendarCheck size={14} className="mr-1.5" />
+              Assign budget
+            </Button>
+          )}
+        </div>
+
+        {showAssignForm && (
+          <div className="rounded-xl border border-border bg-card p-5">
+            <p className="text-sm font-medium mb-4">Assign a budget to a month</p>
+            <AssignBudgetForm
+              budgets={budgets ?? []}
+              onSuccess={() => setShowAssignForm(false)}
+              onCancel={() => setShowAssignForm(false)}
+            />
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-14 w-full rounded-xl" />
+            <Skeleton className="h-14 w-full rounded-xl" />
+            <Skeleton className="h-14 w-full rounded-xl" />
+          </div>
+        ) : (
+          <AssignmentHistory
+            assignments={assignments ?? []}
+            budgets={budgets ?? []}
+            onDelete={deleteAssignment}
+            isDeleting={deletingAssignment}
+          />
+        )}
+      </section>
+    </div>
+  );
 }

--- a/frontend/src/pages/Budgets.tsx
+++ b/frontend/src/pages/Budgets.tsx
@@ -463,16 +463,27 @@ function BudgetForm({
 interface CreateBudgetFormProps {
   onSuccess: () => void;
   onCancel: () => void;
+  prefillBudget?: Budget;
 }
 
-function CreateBudgetForm({ onSuccess, onCancel }: CreateBudgetFormProps) {
+function CreateBudgetForm({ onSuccess, onCancel, prefillBudget }: CreateBudgetFormProps) {
   const { mutate, isPending } = useCreateBudget();
 
-  const defaultValues: BudgetFormValues = {
-    categoryLimits: Object.fromEntries(SPENDING_CATEGORIES.map((c) => [c, 0])),
-    incomeEstimate: 0,
-    note: "",
-  };
+  const defaultValues: BudgetFormValues = prefillBudget
+    ? {
+        categoryLimits: Object.fromEntries(
+          SPENDING_CATEGORIES.map((c) => [c, prefillBudget.categoryLimits[c] ?? 0]),
+        ),
+        incomeEstimate:
+          prefillBudget.netGainOrLoss +
+          Object.values(prefillBudget.categoryLimits).reduce((s, v) => s + v, 0),
+        note: prefillBudget.note ?? "",
+      }
+    : {
+        categoryLimits: Object.fromEntries(SPENDING_CATEGORIES.map((c) => [c, 0])),
+        incomeEstimate: 0,
+        note: "",
+      };
 
   function onSubmit(values: BudgetFormValues) {
     const income = Number(values.incomeEstimate) || 0;
@@ -557,6 +568,65 @@ function EditBudgetForm({ budget, onSuccess, onCancel }: EditBudgetFormProps) {
   );
 }
 
+// ─── Edit warning dialog ──────────────────────────────────────────────────────
+
+interface EditWarningDialogProps {
+  pastMonths: string[];
+  onCreateNew: () => void;
+  onClose: () => void;
+}
+
+function EditWarningDialog({ pastMonths, onCreateNew, onClose }: EditWarningDialogProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-card border border-border rounded-xl shadow-xl w-full max-w-sm">
+        <div className="flex items-center justify-between p-5 border-b border-border">
+          <div className="flex items-center gap-2">
+            <AlertTriangle size={16} className="text-amber-500" />
+            <h2 className="text-sm font-semibold">Unable to edit budget</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <p className="text-sm text-muted-foreground">
+            This budget is assigned to past months that can no longer be changed. Editing
+            it in place would retroactively alter those months.
+          </p>
+
+          <div className="rounded-lg border border-border bg-muted/30 p-3 space-y-1 max-h-32 overflow-y-auto">
+            {pastMonths.map((m) => (
+              <p key={m} className="text-xs text-muted-foreground">{formatMonth(m)}</p>
+            ))}
+          </div>
+
+          <p className="text-sm text-muted-foreground">
+            Would you like to create a new budget pre-filled with these values instead?
+          </p>
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button onClick={onCreateNew}>
+              Create new budget
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ─── Budget card ──────────────────────────────────────────────────────────────
 
 interface BudgetCardProps {
@@ -566,6 +636,7 @@ interface BudgetCardProps {
   allBudgets: Budget[];
   onDeleteRequest: (budget: Budget) => void;
   onAssignAsCurrent: (budgetId: string) => void;
+  onCreateFromBudget: (budget: Budget) => void;
   isAssigning: boolean;
 }
 
@@ -576,13 +647,42 @@ function BudgetCard({
   allBudgets,
   onDeleteRequest,
   onAssignAsCurrent,
+  onCreateFromBudget,
   isAssigning,
 }: BudgetCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
+  const [showEditWarning, setShowEditWarning] = useState(false);
 
   const limits = Object.entries(budget.categoryLimits);
   const period = getBudgetPeriod(budget.id, assignments);
+
+  // Months before the current month where this budget was the effective budget
+  const pastMonthsAssigned = (() => {
+    const own = assignments.filter((a) => a.budgetId === budget.id);
+    if (own.length === 0) return [];
+    const earliest = own.sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom))[0];
+    const past: string[] = [];
+    const today = currentMonth();
+    let cursor = earliest.effectiveFrom;
+    while (cursor < today) {
+      if (getEffectiveBudget(assignments, cursor)?.budgetId === budget.id) {
+        past.push(cursor);
+      }
+      const [y, m] = cursor.split("-").map(Number);
+      cursor = m === 12 ? `${y + 1}-01` : `${y}-${String(m + 1).padStart(2, "0")}`;
+    }
+    return past;
+  })();
+
+  function handleEditClick() {
+    if (pastMonthsAssigned.length > 0) {
+      setShowEditWarning(true);
+    } else {
+      setEditing(true);
+      setExpanded(false);
+    }
+  }
 
   return (
     <div
@@ -626,7 +726,7 @@ function BudgetCard({
               variant="ghost"
               size="sm"
               className="h-7 px-2 text-muted-foreground"
-              onClick={() => { setEditing(true); setExpanded(false); }}
+              onClick={handleEditClick}
               title="Edit this budget"
             >
               <Pencil size={14} />
@@ -697,6 +797,17 @@ function BudgetCard({
             </p>
           )}
         </div>
+      )}
+
+      {showEditWarning && (
+        <EditWarningDialog
+          pastMonths={pastMonthsAssigned}
+          onCreateNew={() => {
+            setShowEditWarning(false);
+            onCreateFromBudget(budget);
+          }}
+          onClose={() => setShowEditWarning(false)}
+        />
       )}
     </div>
   );
@@ -874,7 +985,13 @@ export default function Budgets() {
   const { mutate: assignAsCurrent, isPending: assigning } = useCreateBudgetAssignment();
 
   const [showCreateBudget, setShowCreateBudget] = useState(false);
+  const [prefillBudget, setPrefillBudget] = useState<Budget | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Budget | null>(null);
+
+  function handleCreateFromBudget(budget: Budget) {
+    setPrefillBudget(budget);
+    setShowCreateBudget(true);
+  }
 
   const isLoading = loadingBudgets || loadingAssignments;
   const isError = errorBudgets || errorAssignments;
@@ -987,10 +1104,13 @@ export default function Budgets() {
 
         {showCreateBudget && (
           <div className="rounded-xl border border-border bg-card p-5">
-            <p className="text-sm font-medium mb-4">Create new budget</p>
+            <p className="text-sm font-medium mb-4">
+              {prefillBudget ? "Create new budget (pre-filled from existing)" : "Create new budget"}
+            </p>
             <CreateBudgetForm
-              onSuccess={() => setShowCreateBudget(false)}
-              onCancel={() => setShowCreateBudget(false)}
+              prefillBudget={prefillBudget ?? undefined}
+              onSuccess={() => { setShowCreateBudget(false); setPrefillBudget(null); }}
+              onCancel={() => { setShowCreateBudget(false); setPrefillBudget(null); }}
             />
           </div>
         )}
@@ -1015,6 +1135,7 @@ export default function Budgets() {
                 allBudgets={budgets ?? []}
                 onDeleteRequest={setDeleteTarget}
                 onAssignAsCurrent={handleAssignAsCurrent}
+                onCreateFromBudget={handleCreateFromBudget}
                 isAssigning={assigning}
               />
             ))}

--- a/frontend/src/pages/Budgets.tsx
+++ b/frontend/src/pages/Budgets.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CATEGORY_MAPPING } from "@/constants/categories";
 import {
   useBudgetAssignments,
@@ -7,32 +8,53 @@ import {
   useCreateBudget,
   useCreateBudgetAssignment,
   useDeleteBudget,
-  useDeleteBudgetAssignment,
+  useUpdateBudget,
 } from "@/hooks/useBudgets";
-import { getEffectiveBudget } from "@/lib/budget";
+import { getBudgetPeriod, getEffectiveBudget } from "@/lib/budget";
 import { currentMonth, formatCurrency, formatDate, formatMonth } from "@/lib/formatters";
 import type { Budget, BudgetAssignment } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   AlertCircle,
+  AlertTriangle,
   CalendarCheck,
   CheckCircle2,
   ChevronDown,
   ChevronUp,
+  HelpCircle,
+  Pencil,
   PlusCircle,
   RefreshCw,
   Trash2,
   Wallet,
+  X,
 } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { z } from "zod";
 
-// ─── Primary spending categories (excludes flow-through categories) ────────────
+// ─── Primary spending categories ──────────────────────────────────────────────
 
 const SPENDING_CATEGORIES = Object.keys(CATEGORY_MAPPING).filter(
   (c) => !["Income", "Transfers", "Debt payments", "Investments", "Bank fees"].includes(c),
 );
+
+// ─── Chart colors ─────────────────────────────────────────────────────────────
+
+const CHART_COLORS = [
+  "#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6",
+  "#06b6d4", "#f97316", "#84cc16", "#ec4899", "#14b8a6",
+];
 
 // ─── Zod schemas ──────────────────────────────────────────────────────────────
 
@@ -42,19 +64,10 @@ const budgetSchema = z.object({
     z.number({ error: "Must be a number" }).min(0, "Must be ≥ 0"),
   ),
   incomeEstimate: z.number({ error: "Must be a number" }).min(0, "Must be ≥ 0"),
-});
-
-type BudgetFormValues = z.infer<typeof budgetSchema>;
-
-const assignmentSchema = z.object({
-  budgetId: z.string().min(1, "Select a budget"),
-  effectiveFrom: z
-    .string()
-    .regex(/^\d{4}-\d{2}$/, "Must be YYYY-MM format"),
   note: z.string().max(200, "Max 200 characters").optional(),
 });
 
-type AssignmentFormValues = z.infer<typeof assignmentSchema>;
+type BudgetFormValues = z.infer<typeof budgetSchema>;
 
 // ─── Skeleton components ──────────────────────────────────────────────────────
 
@@ -93,6 +106,29 @@ function ErrorCard({ message, onRetry }: { message: string; onRetry: () => void 
   );
 }
 
+// ─── Info tooltip ─────────────────────────────────────────────────────────────
+
+function InfoTooltip({ text }: { text: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="More info"
+          >
+            <HelpCircle size={14} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="max-w-64 text-xs leading-relaxed">
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 // ─── Active budget card ───────────────────────────────────────────────────────
 
 interface ActiveBudgetCardProps {
@@ -110,12 +146,13 @@ function ActiveBudgetCard({ budgets, assignments }: ActiveBudgetCardProps) {
       <div className="rounded-xl border border-dashed border-border bg-muted/30 p-5 flex items-center gap-3">
         <CalendarCheck size={18} className="text-muted-foreground shrink-0" />
         <p className="text-sm text-muted-foreground">
-          No budget is currently active. Assign a budget below to get started.
+          No budget is currently active. Use "Assign as current" on a budget below.
         </p>
       </div>
     );
   }
 
+  const period = getBudgetPeriod(budget.id, assignments);
   const limitTotal = Object.values(budget.categoryLimits).reduce((s, v) => s + v, 0);
 
   return (
@@ -125,12 +162,13 @@ function ActiveBudgetCard({ budgets, assignments }: ActiveBudgetCardProps) {
         <span className="text-xs font-medium uppercase tracking-wide">Active budget</span>
       </div>
       <div className="flex items-baseline gap-3 flex-wrap">
-        <span className="text-lg font-semibold">
-          Created {formatDate(budget.dateCreated)}
-        </span>
-        <span className="text-sm text-muted-foreground">
-          assigned from {formatMonth(active.effectiveFrom)}
-        </span>
+        {period ? (
+          <span className="text-lg font-semibold">
+            {formatMonth(period.from)} – {period.to ? formatMonth(period.to) : "present"}
+          </span>
+        ) : (
+          <span className="text-lg font-semibold">Created {formatDate(budget.dateCreated)}</span>
+        )}
       </div>
       <div className="flex gap-6 text-sm text-muted-foreground pt-1">
         <span>
@@ -150,111 +188,167 @@ function ActiveBudgetCard({ budgets, assignments }: ActiveBudgetCardProps) {
           </span>
         </span>
       </div>
-      {active.note && (
+      {budget.note && (
         <p className="text-xs text-muted-foreground border-t border-border/50 pt-2 mt-2">
-          {active.note}
+          {budget.note}
         </p>
       )}
     </div>
   );
 }
 
-// ─── Budget card (in list) ────────────────────────────────────────────────────
+// ─── Budget delete dialog ─────────────────────────────────────────────────────
 
-interface BudgetCardProps {
+interface BudgetDeleteDialogProps {
   budget: Budget;
-  isActive: boolean;
-  onDelete: (id: string) => void;
-  isDeleting: boolean;
+  allBudgets: Budget[];
+  assignments: BudgetAssignment[];
+  isPending: boolean;
+  onConfirm: (replacementBudgetId: string | null) => void;
+  onClose: () => void;
 }
 
-function BudgetCard({ budget, isActive, onDelete, isDeleting }: BudgetCardProps) {
-  const [expanded, setExpanded] = useState(false);
-  const limits = Object.entries(budget.categoryLimits);
+function BudgetDeleteDialog({
+  budget,
+  allBudgets,
+  assignments,
+  isPending,
+  onConfirm,
+  onClose,
+}: BudgetDeleteDialogProps) {
+  const [replacementId, setReplacementId] = useState("");
+
+  // Find all months where this budget is the effective budget
+  const affectedMonths: string[] = [];
+  if (assignments.length > 0) {
+    const earliest = assignments
+      .filter((a) => a.budgetId === budget.id)
+      .sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom))[0];
+
+    if (earliest) {
+      const start = earliest.effectiveFrom;
+      const end = currentMonth();
+      let cursor = start;
+      while (cursor <= end) {
+        const effective = getEffectiveBudget(assignments, cursor);
+        if (effective?.budgetId === budget.id) {
+          affectedMonths.push(cursor);
+        }
+        // advance cursor by 1 month
+        const [y, m] = cursor.split("-").map(Number);
+        cursor = m === 12
+          ? `${y + 1}-01`
+          : `${y}-${String(m + 1).padStart(2, "0")}`;
+      }
+    }
+  }
+
+  const otherBudgets = allBudgets.filter((b) => b.id !== budget.id);
+  const hasAffectedMonths = affectedMonths.length > 0;
+  const canConfirm = !hasAffectedMonths || replacementId !== "";
 
   return (
     <div
-      className={`rounded-xl border bg-card p-5 space-y-3 ${
-        isActive ? "border-primary/40" : "border-border"
-      }`}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div>
+      <div className="bg-card border border-border rounded-xl shadow-xl w-full max-w-sm">
+        <div className="flex items-center justify-between p-5 border-b border-border">
           <div className="flex items-center gap-2">
-            <Wallet size={15} className="text-muted-foreground" />
-            <span className="text-sm font-medium">
-              Created {formatDate(budget.dateCreated)}
-            </span>
-            {isActive && (
-              <span className="text-[10px] font-semibold uppercase tracking-wide text-primary bg-primary/10 rounded px-1.5 py-0.5">
-                Active
-              </span>
-            )}
+            <AlertTriangle size={16} className="text-destructive" />
+            <h2 className="text-sm font-semibold">Delete Budget</h2>
           </div>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            {limits.length} categor{limits.length === 1 ? "y" : "ies"} ·{" "}
-            Net:{" "}
-            <span
-              className={
-                budget.netGainOrLoss >= 0
-                  ? "text-green-600 dark:text-green-400"
-                  : "text-destructive"
-              }
-            >
-              {formatCurrency(budget.netGainOrLoss)}
-            </span>
-          </p>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
         </div>
-        <div className="flex items-center gap-1 shrink-0">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2 text-muted-foreground"
-            onClick={() => setExpanded((e) => !e)}
-          >
-            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2 text-destructive hover:text-destructive"
-            onClick={() => onDelete(budget.id)}
-            disabled={isDeleting}
-          >
-            <Trash2 size={14} />
-          </Button>
+
+        <div className="p-5 space-y-4">
+          {hasAffectedMonths ? (
+            <>
+              <p className="text-sm text-muted-foreground">
+                This budget is currently assigned to{" "}
+                <span className="font-medium text-foreground">
+                  {affectedMonths.length} month{affectedMonths.length !== 1 ? "s" : ""}
+                </span>
+                . You must choose a replacement before deleting.
+              </p>
+
+              <div className="rounded-lg border border-border bg-muted/30 p-3 space-y-1 max-h-32 overflow-y-auto">
+                {affectedMonths.map((m) => (
+                  <p key={m} className="text-xs text-muted-foreground">{formatMonth(m)}</p>
+                ))}
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Replacement budget</label>
+                <select
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  value={replacementId}
+                  onChange={(e) => setReplacementId(e.target.value)}
+                >
+                  <option value="">Select a replacement…</option>
+                  {otherBudgets.map((b) => {
+                    const period = getBudgetPeriod(b.id, assignments);
+                    const label = period
+                      ? `${formatMonth(period.from)}${period.to ? ` – ${formatMonth(period.to)}` : " – present"}`
+                      : `Created ${formatDate(b.dateCreated)}`;
+                    return (
+                      <option key={b.id} value={b.id}>
+                        {label} — Net {formatCurrency(b.netGainOrLoss)}
+                      </option>
+                    );
+                  })}
+                </select>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Are you sure you want to delete this budget? This action cannot be undone.
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={onClose} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={isPending || !canConfirm}
+              onClick={() => onConfirm(replacementId || null)}
+            >
+              {isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </div>
         </div>
       </div>
-
-      {expanded && (
-        <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 border-t border-border pt-3 text-sm">
-          {limits.map(([category, limit]) => (
-            <div key={category} className="flex justify-between gap-2">
-              <span className="text-muted-foreground truncate">{category}</span>
-              <span className="font-medium tabular-nums">{formatCurrency(limit)}</span>
-            </div>
-          ))}
-        </div>
-      )}
     </div>
   );
 }
 
-// ─── Create budget form ───────────────────────────────────────────────────────
+// ─── Shared budget form fields ────────────────────────────────────────────────
 
-interface CreateBudgetFormProps {
-  onSuccess: () => void;
+interface BudgetFormProps {
+  defaultValues: BudgetFormValues;
+  isPending: boolean;
+  submitLabel: string;
+  pendingLabel: string;
+  onSubmit: (values: BudgetFormValues) => void;
   onCancel: () => void;
 }
 
-function CreateBudgetForm({ onSuccess, onCancel }: CreateBudgetFormProps) {
-  const { mutate, isPending } = useCreateBudget();
-
-  const defaultValues: BudgetFormValues = {
-    categoryLimits: Object.fromEntries(SPENDING_CATEGORIES.map((c) => [c, 0])),
-    incomeEstimate: 0,
-  };
-
+function BudgetForm({
+  defaultValues,
+  isPending,
+  submitLabel,
+  pendingLabel,
+  onSubmit,
+  onCancel,
+}: BudgetFormProps) {
   const {
     register,
     handleSubmit,
@@ -271,20 +365,6 @@ function CreateBudgetForm({ onSuccess, onCancel }: CreateBudgetFormProps) {
     0,
   );
   const net = (Number(watched.incomeEstimate) || 0) - totalLimits;
-
-  function onSubmit(values: BudgetFormValues) {
-    const income = Number(values.incomeEstimate) || 0;
-    const limits: Record<string, number> = {};
-    for (const [cat, val] of Object.entries(values.categoryLimits)) {
-      const n = Number(val);
-      if (n > 0) limits[cat] = n;
-    }
-    const limitSum = Object.values(limits).reduce((s, v) => s + v, 0);
-    mutate(
-      { categoryLimits: limits, netGainOrLoss: income - limitSum },
-      { onSuccess },
-    );
-  }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
@@ -326,10 +406,26 @@ function CreateBudgetForm({ onSuccess, onCancel }: CreateBudgetFormProps) {
         </div>
       </div>
 
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Note (optional)</label>
+        <input
+          type="text"
+          placeholder="e.g. Post-raise revision"
+          maxLength={200}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          {...register("note")}
+        />
+        {errors.note && (
+          <p className="text-xs text-destructive">{errors.note.message}</p>
+        )}
+      </div>
+
       {/* Live net calculation */}
       <div className="rounded-lg border border-border bg-muted/30 px-4 py-3 flex items-center justify-between">
         <div className="text-sm text-muted-foreground">
-          <span className="text-foreground font-medium">{formatCurrency(Number(watched.incomeEstimate) || 0)}</span>
+          <span className="text-foreground font-medium">
+            {formatCurrency(Number(watched.incomeEstimate) || 0)}
+          </span>
           {" income − "}
           <span className="text-foreground font-medium">{formatCurrency(totalLimits)}</span>
           {" limits"}
@@ -347,169 +443,385 @@ function CreateBudgetForm({ onSuccess, onCancel }: CreateBudgetFormProps) {
           Cancel
         </Button>
         <Button type="submit" disabled={isPending}>
-          {isPending ? "Saving…" : "Create budget"}
+          {isPending ? pendingLabel : submitLabel}
         </Button>
       </div>
     </form>
   );
 }
 
-// ─── Budget assignment form ───────────────────────────────────────────────────
+// ─── Create budget form ───────────────────────────────────────────────────────
 
-interface AssignBudgetFormProps {
-  budgets: Budget[];
+interface CreateBudgetFormProps {
   onSuccess: () => void;
   onCancel: () => void;
 }
 
-function AssignBudgetForm({ budgets, onSuccess, onCancel }: AssignBudgetFormProps) {
-  const { mutate, isPending } = useCreateBudgetAssignment();
+function CreateBudgetForm({ onSuccess, onCancel }: CreateBudgetFormProps) {
+  const { mutate, isPending } = useCreateBudget();
 
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<AssignmentFormValues>({
-    resolver: zodResolver(assignmentSchema),
-    defaultValues: { budgetId: "", effectiveFrom: currentMonth(), note: "" },
-  });
+  const defaultValues: BudgetFormValues = {
+    categoryLimits: Object.fromEntries(SPENDING_CATEGORIES.map((c) => [c, 0])),
+    incomeEstimate: 0,
+    note: "",
+  };
 
-  function onSubmit(values: AssignmentFormValues) {
+  function onSubmit(values: BudgetFormValues) {
+    const income = Number(values.incomeEstimate) || 0;
+    const limits: Record<string, number> = {};
+    for (const [cat, val] of Object.entries(values.categoryLimits)) {
+      const n = Number(val);
+      if (n > 0) limits[cat] = n;
+    }
+    const limitSum = Object.values(limits).reduce((s, v) => s + v, 0);
     mutate(
       {
-        budgetId: values.budgetId,
-        effectiveFrom: values.effectiveFrom,
-        note: values.note || null,
+        categoryLimits: limits,
+        netGainOrLoss: income - limitSum,
+        note: values.note?.trim() || null,
       },
       { onSuccess },
     );
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      <div className="space-y-1">
-        <label className="text-sm font-medium">Budget</label>
-        <select
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          {...register("budgetId")}
-        >
-          <option value="">Select a budget…</option>
-          {budgets.map((b) => (
-            <option key={b.id} value={b.id}>
-              Created {formatDate(b.dateCreated)} — Net {formatCurrency(b.netGainOrLoss)}
-            </option>
-          ))}
-        </select>
-        {errors.budgetId && (
-          <p className="text-xs text-destructive">{errors.budgetId.message}</p>
-        )}
-      </div>
-
-      <div className="space-y-1">
-        <label className="text-sm font-medium">Effective from (YYYY-MM)</label>
-        <input
-          type="text"
-          placeholder="2025-01"
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          {...register("effectiveFrom")}
-        />
-        {errors.effectiveFrom && (
-          <p className="text-xs text-destructive">{errors.effectiveFrom.message}</p>
-        )}
-      </div>
-
-      <div className="space-y-1">
-        <label className="text-sm font-medium">Note (optional)</label>
-        <input
-          type="text"
-          placeholder="e.g. New Year revision"
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          {...register("note")}
-        />
-        {errors.note && (
-          <p className="text-xs text-destructive">{errors.note.message}</p>
-        )}
-      </div>
-
-      <div className="flex justify-end gap-2 pt-1">
-        <Button type="button" variant="outline" onClick={onCancel} disabled={isPending}>
-          Cancel
-        </Button>
-        <Button type="submit" disabled={isPending}>
-          {isPending ? "Assigning…" : "Assign budget"}
-        </Button>
-      </div>
-    </form>
+    <BudgetForm
+      defaultValues={defaultValues}
+      isPending={isPending}
+      submitLabel="Create budget"
+      pendingLabel="Saving…"
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    />
   );
 }
 
-// ─── Assignment history list ──────────────────────────────────────────────────
+// ─── Edit budget form ─────────────────────────────────────────────────────────
 
-interface AssignmentHistoryProps {
-  assignments: BudgetAssignment[];
-  budgets: Budget[];
-  onDelete: (id: string) => void;
-  isDeleting: boolean;
+interface EditBudgetFormProps {
+  budget: Budget;
+  onSuccess: () => void;
+  onCancel: () => void;
 }
 
-function AssignmentHistory({
-  assignments,
-  budgets,
-  onDelete,
-  isDeleting,
-}: AssignmentHistoryProps) {
-  const sorted = [...assignments].sort((a, b) =>
-    b.effectiveFrom.localeCompare(a.effectiveFrom),
-  );
+function EditBudgetForm({ budget, onSuccess, onCancel }: EditBudgetFormProps) {
+  const { mutate, isPending } = useUpdateBudget();
 
-  if (sorted.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground py-2">
-        No assignments yet. Assign a budget above to start.
-      </p>
+  const limitSum = Object.values(budget.categoryLimits).reduce((s, v) => s + v, 0);
+  const defaultValues: BudgetFormValues = {
+    categoryLimits: Object.fromEntries(
+      SPENDING_CATEGORIES.map((c) => [c, budget.categoryLimits[c] ?? 0]),
+    ),
+    incomeEstimate: budget.netGainOrLoss + limitSum,
+    note: budget.note ?? "",
+  };
+
+  function onSubmit(values: BudgetFormValues) {
+    const income = Number(values.incomeEstimate) || 0;
+    const limits: Record<string, number> = {};
+    for (const [cat, val] of Object.entries(values.categoryLimits)) {
+      const n = Number(val);
+      if (n > 0) limits[cat] = n;
+    }
+    const newLimitSum = Object.values(limits).reduce((s, v) => s + v, 0);
+    mutate(
+      {
+        id: budget.id,
+        payload: {
+          categoryLimits: limits,
+          netGainOrLoss: income - newLimitSum,
+          note: values.note?.trim() || null,
+        },
+      },
+      { onSuccess },
     );
   }
 
   return (
-    <div className="divide-y divide-border rounded-xl border border-border overflow-hidden">
-      {sorted.map((a) => {
-        const budget = budgets.find((b) => b.id === a.budgetId);
-        return (
-          <div key={a.id} className="flex items-center justify-between gap-4 px-4 py-3 bg-card">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-sm font-medium">{formatMonth(a.effectiveFrom)}</span>
-                {budget && (
-                  <span className="text-xs text-muted-foreground">
-                    Budget created {formatDate(budget.dateCreated)} · Net{" "}
-                    <span
-                      className={
-                        budget.netGainOrLoss >= 0
-                          ? "text-green-600 dark:text-green-400"
-                          : "text-destructive"
-                      }
-                    >
-                      {formatCurrency(budget.netGainOrLoss)}
-                    </span>
-                  </span>
-                )}
-              </div>
-              {a.note && (
-                <p className="text-xs text-muted-foreground mt-0.5 truncate">{a.note}</p>
-              )}
-            </div>
+    <BudgetForm
+      defaultValues={defaultValues}
+      isPending={isPending}
+      submitLabel="Save changes"
+      pendingLabel="Saving…"
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    />
+  );
+}
+
+// ─── Budget card ──────────────────────────────────────────────────────────────
+
+interface BudgetCardProps {
+  budget: Budget;
+  isActive: boolean;
+  assignments: BudgetAssignment[];
+  allBudgets: Budget[];
+  onDeleteRequest: (budget: Budget) => void;
+  onAssignAsCurrent: (budgetId: string) => void;
+  isAssigning: boolean;
+}
+
+function BudgetCard({
+  budget,
+  isActive,
+  assignments,
+  allBudgets,
+  onDeleteRequest,
+  onAssignAsCurrent,
+  isAssigning,
+}: BudgetCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  const limits = Object.entries(budget.categoryLimits);
+  const period = getBudgetPeriod(budget.id, assignments);
+
+  return (
+    <div
+      className={`rounded-xl border bg-card p-5 space-y-3 ${
+        isActive ? "border-primary/40" : "border-border"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Wallet size={15} className="text-muted-foreground" />
+            <span className="text-sm font-medium">
+              {period
+                ? `${formatMonth(period.from)} – ${period.to ? formatMonth(period.to) : "present"}`
+                : `Created ${formatDate(budget.dateCreated)}`}
+            </span>
+            {isActive && (
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-primary bg-primary/10 rounded px-1.5 py-0.5">
+                Active
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {limits.length} categor{limits.length === 1 ? "y" : "ies"} ·{" "}
+            Net:{" "}
+            <span
+              className={
+                budget.netGainOrLoss >= 0
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-destructive"
+              }
+            >
+              {formatCurrency(budget.netGainOrLoss)}
+            </span>
+          </p>
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          {isActive && !editing && (
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 px-2 text-destructive hover:text-destructive shrink-0"
-              onClick={() => onDelete(a.id)}
-              disabled={isDeleting}
+              className="h-7 px-2 text-muted-foreground"
+              onClick={() => { setEditing(true); setExpanded(false); }}
+              title="Edit this budget"
             >
-              <Trash2 size={14} />
+              <Pencil size={14} />
             </Button>
+          )}
+          {!isActive && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-muted-foreground hover:text-primary"
+              onClick={() => onAssignAsCurrent(budget.id)}
+              disabled={isAssigning}
+              title="Assign as current month's budget"
+            >
+              <CalendarCheck size={14} />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-muted-foreground"
+            onClick={() => { setExpanded((e) => !e); setEditing(false); }}
+          >
+            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-destructive hover:text-destructive"
+            onClick={() => onDeleteRequest(budget)}
+          >
+            <Trash2 size={14} />
+          </Button>
+        </div>
+      </div>
+
+      {editing && (
+        <div className="border-t border-border pt-4">
+          <EditBudgetForm
+            budget={budget}
+            onSuccess={() => setEditing(false)}
+            onCancel={() => setEditing(false)}
+          />
+        </div>
+      )}
+
+      {expanded && !editing && (
+        <div className="space-y-3 border-t border-border pt-3">
+          <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 text-sm">
+            {limits.map(([category, limit]) => (
+              <div key={category} className="flex justify-between gap-2">
+                <span className="text-muted-foreground truncate">{category}</span>
+                <span className="font-medium tabular-nums">{formatCurrency(limit)}</span>
+              </div>
+            ))}
           </div>
-        );
-      })}
+          {budget.note && (
+            <p className="text-xs text-muted-foreground border-t border-border/50 pt-2">
+              {budget.note}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Budget limits chart ──────────────────────────────────────────────────────
+
+type ChartView = "total" | "per-category";
+
+interface BudgetLimitsChartProps {
+  budgets: Budget[];
+  assignments: BudgetAssignment[];
+}
+
+function BudgetLimitsChart({ budgets, assignments }: BudgetLimitsChartProps) {
+  const [view, setView] = useState<ChartView>("total");
+
+  if (assignments.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-2">
+        No assignments yet. Assign a budget above to see how limits change over time.
+      </p>
+    );
+  }
+
+  // Build month range from earliest assignment to current month
+  const sortedAssignments = [...assignments].sort((a, b) =>
+    a.effectiveFrom.localeCompare(b.effectiveFrom),
+  );
+  const startMonth = sortedAssignments[0].effectiveFrom;
+  const endMonth = currentMonth();
+
+  const months: string[] = [];
+  let cursor = startMonth;
+  while (cursor <= endMonth) {
+    months.push(cursor);
+    const [y, m] = cursor.split("-").map(Number);
+    cursor = m === 12
+      ? `${y + 1}-01`
+      : `${y}-${String(m + 1).padStart(2, "0")}`;
+  }
+
+  // All unique categories across all budgets
+  const allCategories = Array.from(
+    new Set(budgets.flatMap((b) => Object.keys(b.categoryLimits))),
+  ).sort();
+
+  // Build chart data
+  const data = months.map((month) => {
+    const assignment = getEffectiveBudget(assignments, month);
+    const budget = assignment ? budgets.find((b) => b.id === assignment.budgetId) : null;
+    const row: Record<string, string | number> = {
+      month: formatMonth(month).replace(" ", "\n"),
+      monthFull: month,
+    };
+    if (view === "total") {
+      row.Total = budget
+        ? Object.values(budget.categoryLimits).reduce((s, v) => s + v, 0)
+        : 0;
+    } else {
+      for (const cat of allCategories) {
+        row[cat] = budget?.categoryLimits[cat] ?? 0;
+      }
+    }
+    return row;
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Button
+          variant={view === "total" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setView("total")}
+        >
+          Total
+        </Button>
+        <Button
+          variant={view === "per-category" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setView("per-category")}
+        >
+          Per category
+        </Button>
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-4">
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart data={data} margin={{ top: 8, right: 16, left: 0, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+            <XAxis
+              dataKey="month"
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              tickLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`}
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              tickLine={false}
+              axisLine={false}
+              width={48}
+            />
+            <RechartsTooltip
+              formatter={(value: number, name: string) => [formatCurrency(value), name]}
+              labelFormatter={(label) => label}
+              contentStyle={{
+                backgroundColor: "var(--card)",
+                border: "1px solid var(--border)",
+                borderRadius: "8px",
+                fontSize: "12px",
+              }}
+            />
+            {view === "total" ? (
+              <Line
+                type="stepAfter"
+                dataKey="Total"
+                stroke={CHART_COLORS[0]}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+            ) : (
+              <>
+                {allCategories.map((cat, i) => (
+                  <Line
+                    key={cat}
+                    type="stepAfter"
+                    dataKey={cat}
+                    stroke={CHART_COLORS[i % CHART_COLORS.length]}
+                    strokeWidth={1.5}
+                    dot={false}
+                    activeDot={{ r: 3 }}
+                  />
+                ))}
+                <Legend wrapperStyle={{ fontSize: "11px" }} />
+              </>
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }
@@ -532,19 +844,56 @@ export default function Budgets() {
   } = useBudgetAssignments();
 
   const { mutate: deleteBudget, isPending: deletingBudget } = useDeleteBudget();
-  const { mutate: deleteAssignment, isPending: deletingAssignment } =
-    useDeleteBudgetAssignment();
+  const { mutate: assignAsCurrent, isPending: assigning } = useCreateBudgetAssignment();
 
   const [showCreateBudget, setShowCreateBudget] = useState(false);
-  const [showAssignForm, setShowAssignForm] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Budget | null>(null);
 
   const isLoading = loadingBudgets || loadingAssignments;
   const isError = errorBudgets || errorAssignments;
 
   const activeAssignment =
-    budgets && assignments
-      ? getEffectiveBudget(assignments, currentMonth())
-      : null;
+    budgets && assignments ? getEffectiveBudget(assignments, currentMonth()) : null;
+
+  function handleAssignAsCurrent(budgetId: string) {
+    assignAsCurrent({ budgetId, effectiveFrom: currentMonth(), note: null });
+  }
+
+  function handleDeleteConfirm(replacementBudgetId: string | null) {
+    if (!deleteTarget) return;
+
+    const affectedAssignmentIds = (assignments ?? [])
+      .filter((a) => a.budgetId === deleteTarget.id)
+      .map((a) => a.id);
+
+    if (replacementBudgetId && affectedAssignmentIds.length > 0) {
+      // Reassign all affected months to the replacement, then delete
+      // Compute affected months (same logic as BudgetDeleteDialog)
+      const sortedOwn = (assignments ?? [])
+        .filter((a) => a.budgetId === deleteTarget.id)
+        .sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom));
+
+      if (sortedOwn.length > 0) {
+        const start = sortedOwn[0].effectiveFrom;
+        const end = currentMonth();
+        let cursor = start;
+        while (cursor <= end) {
+          const effective = getEffectiveBudget(assignments ?? [], cursor);
+          if (effective?.budgetId === deleteTarget.id) {
+            assignAsCurrent({ budgetId: replacementBudgetId, effectiveFrom: cursor, note: null });
+          }
+          const [y, m] = cursor.split("-").map(Number);
+          cursor = m === 12
+            ? `${y + 1}-01`
+            : `${y}-${String(m + 1).padStart(2, "0")}`;
+        }
+      }
+    }
+
+    deleteBudget(deleteTarget.id, {
+      onSuccess: () => setDeleteTarget(null),
+    });
+  }
 
   return (
     <div className="p-6 space-y-8 max-w-4xl mx-auto">
@@ -565,6 +914,22 @@ export default function Budgets() {
         />
       )}
 
+      {/* ── Budget limits over time ── */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-1.5">
+          <h2 className="text-base font-semibold">Limits over time</h2>
+          <InfoTooltip text="Shows how your budget limits have changed as you've switched between budgets. Lines step at each transition point." />
+        </div>
+        {isLoading ? (
+          <Skeleton className="h-64 w-full rounded-xl" />
+        ) : (
+          <BudgetLimitsChart
+            budgets={budgets ?? []}
+            assignments={assignments ?? []}
+          />
+        )}
+      </section>
+
       {/* ── Active budget ── */}
       <section className="space-y-3">
         <h2 className="text-base font-semibold">Active budget</h2>
@@ -581,7 +946,10 @@ export default function Budgets() {
       {/* ── Budget list ── */}
       <section className="space-y-3">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-base font-semibold">Budgets</h2>
+          <div className="flex items-center gap-1.5">
+            <h2 className="text-base font-semibold">Budgets</h2>
+            <InfoTooltip text="Only the active budget can be edited. Past budgets are read-only — use 'Assign as current' to reactivate one. Assignments lock at month-end." />
+          </div>
           {!showCreateBudget && (
             <Button size="sm" onClick={() => setShowCreateBudget(true)}>
               <PlusCircle size={14} className="mr-1.5" />
@@ -616,57 +984,28 @@ export default function Budgets() {
                 key={b.id}
                 budget={b}
                 isActive={activeAssignment?.budgetId === b.id}
-                onDelete={deleteBudget}
-                isDeleting={deletingBudget}
+                assignments={assignments ?? []}
+                allBudgets={budgets ?? []}
+                onDeleteRequest={setDeleteTarget}
+                onAssignAsCurrent={handleAssignAsCurrent}
+                isAssigning={assigning}
               />
             ))}
           </div>
         )}
       </section>
 
-      {/* ── Assignment ── */}
-      <section className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-base font-semibold">Assignment history</h2>
-          {!showAssignForm && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setShowAssignForm(true)}
-              disabled={(budgets ?? []).length === 0}
-            >
-              <CalendarCheck size={14} className="mr-1.5" />
-              Assign budget
-            </Button>
-          )}
-        </div>
-
-        {showAssignForm && (
-          <div className="rounded-xl border border-border bg-card p-5">
-            <p className="text-sm font-medium mb-4">Assign a budget to a month</p>
-            <AssignBudgetForm
-              budgets={budgets ?? []}
-              onSuccess={() => setShowAssignForm(false)}
-              onCancel={() => setShowAssignForm(false)}
-            />
-          </div>
-        )}
-
-        {isLoading ? (
-          <div className="space-y-2">
-            <Skeleton className="h-14 w-full rounded-xl" />
-            <Skeleton className="h-14 w-full rounded-xl" />
-            <Skeleton className="h-14 w-full rounded-xl" />
-          </div>
-        ) : (
-          <AssignmentHistory
-            assignments={assignments ?? []}
-            budgets={budgets ?? []}
-            onDelete={deleteAssignment}
-            isDeleting={deletingAssignment}
-          />
-        )}
-      </section>
+      {/* ── Delete dialog ── */}
+      {deleteTarget && (
+        <BudgetDeleteDialog
+          budget={deleteTarget}
+          allBudgets={budgets ?? []}
+          assignments={assignments ?? []}
+          isPending={deletingBudget}
+          onConfirm={handleDeleteConfirm}
+          onClose={() => setDeleteTarget(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Budgets.tsx
+++ b/frontend/src/pages/Budgets.tsx
@@ -188,8 +188,16 @@ function ActiveBudgetCard({ budgets, assignments }: ActiveBudgetCardProps) {
           </span>
         </span>
       </div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 border-t border-primary/20 pt-3 mt-1 text-sm">
+        {Object.entries(budget.categoryLimits).map(([category, limit]) => (
+          <div key={category} className="flex justify-between gap-2">
+            <span className="text-muted-foreground truncate">{category}</span>
+            <span className="font-medium tabular-nums">{formatCurrency(limit)}</span>
+          </div>
+        ))}
+      </div>
       {budget.note && (
-        <p className="text-xs text-muted-foreground border-t border-border/50 pt-2 mt-2">
+        <p className="text-xs text-muted-foreground border-t border-primary/20 pt-2 mt-1">
           {budget.note}
         </p>
       )}
@@ -625,16 +633,24 @@ function BudgetCard({
             </Button>
           )}
           {!isActive && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2 text-muted-foreground hover:text-primary"
-              onClick={() => onAssignAsCurrent(budget.id)}
-              disabled={isAssigning}
-              title="Assign as current month's budget"
-            >
-              <CalendarCheck size={14} />
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-muted-foreground hover:text-primary"
+                    onClick={() => onAssignAsCurrent(budget.id)}
+                    disabled={isAssigning}
+                  >
+                    <CalendarCheck size={14} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  Assign as current month's budget
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           <Button
             variant="ghost"
@@ -690,6 +706,14 @@ function BudgetCard({
 
 type ChartView = "total" | "per-category";
 
+/** Compact axis label: "Jan '25" */
+function shortMonth(yyyyMm: string): string {
+  const [y, m] = yyyyMm.split("-").map(Number);
+  const date = new Date(y, m - 1, 1);
+  const mon = date.toLocaleDateString("en-US", { month: "short" });
+  return `${mon} '${String(y).slice(2)}`;
+}
+
 interface BudgetLimitsChartProps {
   budgets: Budget[];
   assignments: BudgetAssignment[];
@@ -733,7 +757,7 @@ function BudgetLimitsChart({ budgets, assignments }: BudgetLimitsChartProps) {
     const assignment = getEffectiveBudget(assignments, month);
     const budget = assignment ? budgets.find((b) => b.id === assignment.budgetId) : null;
     const row: Record<string, string | number> = {
-      month: formatMonth(month).replace(" ", "\n"),
+      month: shortMonth(month),
       monthFull: month,
     };
     if (view === "total") {
@@ -786,7 +810,10 @@ function BudgetLimitsChart({ budgets, assignments }: BudgetLimitsChartProps) {
             />
             <RechartsTooltip
               formatter={(value: number, name: string) => [formatCurrency(value), name]}
-              labelFormatter={(label) => label}
+              labelFormatter={(label, payload) => {
+                const monthFull = payload?.[0]?.payload?.monthFull;
+                return monthFull ? formatMonth(monthFull) : label;
+              }}
               contentStyle={{
                 backgroundColor: "var(--card)",
                 border: "1px solid var(--border)",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -65,6 +65,7 @@ export interface Budget {
   dateCreated: string; // ISO 8601
   categoryLimits: Record<string, number>; // primaryCategory name → monthly limit
   netGainOrLoss: number; // calculated: income - sum of limits
+  note: string | null; // optional user note
 }
 
 export interface BudgetAssignment {


### PR DESCRIPTION
Closes #8

## Summary

- `src/api/budgets.ts`: full mock CRUD for budgets and assignments (`USE_MOCK=true`), real fetch stubs commented below each mock block
- `src/hooks/useBudgets.ts`: TanStack Query wrappers (`useBudgets`, `useBudgetAssignments`, and all mutation hooks)
- `src/lib/budget.ts`: pure `getEffectiveBudget(assignments, month)` — returns most-recent assignment with `effectiveFrom ≤ month`
- `src/__tests__/budget.test.ts`: 11 unit tests covering no assignments, single/exact/multiple assignments, future-dated, and order independence
- `src/pages/Budgets.tsx`: active budget card, budget list with expand/delete, create-budget form (RHF+Zod, per-category limits, live net calc), assignment form (budget select + YYYY-MM + note), assignment history, skeleton loaders, error card with retry

## Test plan

- [x] All 65 tests pass (`npm test`)
- [x] `tsc --noEmit` clean
- [x] Active budget card shows the correct budget for the current month
- [x] Creating a budget with per-category limits shows correct live net
- [x] Assigning a budget updates the active budget card
- [x] Deleting a budget removes it and its assignments
- [x] Skeleton loaders appear on initial load; error card with retry appears on failure
- [ ] All form fields show field-level errors on invalid input

🤖 Generated with [Claude Code](https://claude.com/claude-code)