### PR TITLE
feat: implement CSVNormalizationPlanner with unit tests

### DIFF
--- a/backend/ai_modules/csv_normalization_planner.py
+++ b/backend/ai_modules/csv_normalization_planner.py
@@ -1,0 +1,127 @@
+#!python3
+from backend.ai_modules.ai_client_service import (
+    AIClientService,
+    ALL_SCHEMA_FIELDS,
+    REQUIRED_SCHEMA_FIELDS,
+)
+from backend.ai_modules.normalization_plan import AmountTransform, CategoryMapping, NormalizationPlan
+from backend.database_modules.managers.category_mapping_rules_manager import CategoryMappingRulesManager
+
+from pleasant_loggers import get_logger
+logger = get_logger(__name__)
+
+_ALL_SCHEMA_FIELD_SET = set(ALL_SCHEMA_FIELDS)
+_REQUIRED_FIELD_SET = set(REQUIRED_SCHEMA_FIELDS)
+
+
+class CSVNormalizationPlanner:
+    """
+    Orchestrates CSV normalization by checking the rules cache before calling the AI.
+
+    Processing order:
+      1. Look up each header and category value in the rules cache.
+      2. If all required fields are covered by cache + exact header matches, and
+         all categories are cached → return plan with zero AI calls.
+      3. For any uncached headers or categories, call AIClientService with only
+         those items.
+      4. Merge cached rules and AI results into a final NormalizationPlan.
+
+    Has no side effects — does not save rules. Rule saving happens separately
+    when the user approves the plan.
+    """
+
+    def __init__(
+        self,
+        rules_manager: CategoryMappingRulesManager,
+        ai_service: AIClientService,
+    ):
+        self._rules = rules_manager
+        self._ai = ai_service
+
+    def plan(
+        self,
+        headers: list[str],
+        unique_categories: list[str],
+    ) -> NormalizationPlan:
+        """
+        Produce a NormalizationPlan for the given CSV headers and category values.
+
+        Args:
+            headers: Raw column header strings from the CSV.
+            unique_categories: Unique category values found in the CSV.
+
+        Returns:
+            NormalizationPlan with column_map, category_map, amount_transform, and issues.
+        """
+        # 1. Check rules cache for all headers and categories
+        cached_col_rules: dict[str, str] = {}
+        for h in headers:
+            rule = self._rules.get_column_rule(h)
+            if rule is not None:
+                cached_col_rules[h] = rule
+
+        cached_cat_rules: dict[str, dict] = {}
+        for c in unique_categories:
+            rule = self._rules.get_category_rule(c)
+            if rule is not None:
+                cached_cat_rules[c] = rule
+
+        # 2. Find items not covered by cache or exact schema field match
+        uncached_headers = [
+            h for h in headers
+            if h not in cached_col_rules and h not in _ALL_SCHEMA_FIELD_SET
+        ]
+        uncached_categories = [
+            c for c in unique_categories if c not in cached_cat_rules
+        ]
+
+        # 3. Call AI only for uncached items, or skip entirely on pure cache hit
+        if uncached_headers or uncached_categories:
+            logger.info(
+                f"Cache miss: sending {len(uncached_headers)} headers and "
+                f"{len(uncached_categories)} categories to AI"
+            )
+            ai_plan = self._ai.plan_csv(uncached_headers, uncached_categories)
+            merged_column_map = {**cached_col_rules, **ai_plan.column_map}
+            merged_category_map = {
+                **{k: CategoryMapping(primary=v["primary"], detailed=v["detailed"])
+                   for k, v in cached_cat_rules.items()},
+                **ai_plan.category_map,
+            }
+            amount_transform = ai_plan.amount_transform
+            debit_column = ai_plan.debit_column
+            credit_column = ai_plan.credit_column
+            issues = ai_plan.issues
+        else:
+            logger.info("Full cache hit: returning plan without AI call")
+            merged_column_map = dict(cached_col_rules)
+            merged_category_map = {
+                k: CategoryMapping(primary=v["primary"], detailed=v["detailed"])
+                for k, v in cached_cat_rules.items()
+            }
+            amount_transform = AmountTransform.SIGNED
+            debit_column = None
+            credit_column = None
+            issues = []
+
+        # 4. Strip identity mappings — headers already named as schema fields
+        #    need no entry in column_map (the transform applicator passes them through)
+        final_column_map = {
+            k: v for k, v in merged_column_map.items()
+            if k not in _ALL_SCHEMA_FIELD_SET
+        }
+
+        # 5. Determine which required fields are reachable after merging
+        covered_fields = set(v for v in final_column_map.values() if v is not None)
+        covered_fields |= {h for h in headers if h in _ALL_SCHEMA_FIELD_SET}
+        unmapped_required = [f for f in REQUIRED_SCHEMA_FIELDS if f not in covered_fields]
+
+        return NormalizationPlan(
+            column_map=final_column_map,
+            category_map=merged_category_map,
+            amount_transform=amount_transform,
+            debit_column=debit_column,
+            credit_column=credit_column,
+            issues=issues,
+            unmapped_required_columns=unmapped_required,
+        )

--- a/backend/tests/test_csv_normalization_planner.py
+++ b/backend/tests/test_csv_normalization_planner.py
@@ -1,0 +1,281 @@
+#!python3
+"""
+Tests for CSVNormalizationPlanner.
+
+Covers:
+    - Exact Budgy column names: empty column_map, no AI call
+    - All categories in cache: plan returned without calling AIClientService
+    - Partial cache hit: only uncached items sent to AI
+    - Missing primary_category: populates unmapped_required_columns
+    - AI and cache results merged correctly into a single NormalizationPlan
+    - Debit/credit pattern: AI called, amount_transform set to DEBIT_CREDIT
+"""
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from backend.ai_modules.normalization_plan import AmountTransform, CategoryMapping, NormalizationPlan
+from backend.ai_modules.ai_client_service import REQUIRED_SCHEMA_FIELDS
+from backend.ai_modules.csv_normalization_planner import CSVNormalizationPlanner
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _make_ai_plan(**kwargs) -> NormalizationPlan:
+    defaults = dict(
+        column_map={},
+        category_map={},
+        amount_transform=AmountTransform.SIGNED,
+        debit_column=None,
+        credit_column=None,
+        issues=[],
+        unmapped_required_columns=[],
+    )
+    defaults.update(kwargs)
+    return NormalizationPlan(**defaults)
+
+
+def _make_planner(
+    col_rules: dict[str, str | None] = None,
+    cat_rules: dict[str, dict | None] = None,
+    ai_plan: NormalizationPlan = None,
+) -> CSVNormalizationPlanner:
+    """
+    Build a CSVNormalizationPlanner with mocked dependencies.
+
+    col_rules: maps raw_header -> schema_field (or None for cache miss)
+    cat_rules: maps raw_category -> {primary, detailed} dict (or None for cache miss)
+    ai_plan: what AIClientService.plan_csv returns
+    """
+    col_rules = col_rules or {}
+    cat_rules = cat_rules or {}
+
+    rules_manager = MagicMock()
+    rules_manager.get_column_rule.side_effect = lambda h: col_rules.get(h)
+    rules_manager.get_category_rule.side_effect = lambda c: cat_rules.get(c)
+
+    ai_service = MagicMock()
+    ai_service.plan_csv.return_value = ai_plan or _make_ai_plan()
+
+    return CSVNormalizationPlanner(rules_manager, ai_service)
+
+
+# ── Exact-match fast path ──────────────────────────────────────────────────────
+
+class TestExactMatchFastPath:
+    """CSV with all column headers already matching Budgy schema fields."""
+
+    EXACT_HEADERS = ["authorized_date", "description", "primary_category", "amount"]
+
+    def test_column_map_is_empty(self):
+        planner = _make_planner()
+        plan = planner.plan(self.EXACT_HEADERS, [])
+        assert plan.column_map == {}
+
+    def test_no_ai_call(self):
+        planner = _make_planner()
+        planner.plan(self.EXACT_HEADERS, [])
+        planner._ai.plan_csv.assert_not_called()
+
+    def test_amount_transform_is_signed(self):
+        planner = _make_planner()
+        plan = planner.plan(self.EXACT_HEADERS, [])
+        assert plan.amount_transform == AmountTransform.SIGNED
+
+    def test_no_unmapped_required_columns(self):
+        planner = _make_planner()
+        plan = planner.plan(self.EXACT_HEADERS, [])
+        assert plan.unmapped_required_columns == []
+
+
+# ── Full cache hit ─────────────────────────────────────────────────────────────
+
+class TestFullCacheHit:
+    """All headers in rules cache, all categories in rules cache."""
+
+    def test_no_ai_call_when_all_cached(self):
+        planner = _make_planner(
+            col_rules={
+                "Txn Date": "authorized_date",
+                "Merchant": "description",
+                "Category": "primary_category",
+                "Amount": "amount",
+            },
+            cat_rules={
+                "Dining Out": {"primary": "Food & drink", "detailed": "Restaurants & bars"},
+            },
+        )
+        planner.plan(["Txn Date", "Merchant", "Category", "Amount"], ["Dining Out"])
+        planner._ai.plan_csv.assert_not_called()
+
+    def test_column_map_built_from_cache(self):
+        planner = _make_planner(
+            col_rules={
+                "Txn Date": "authorized_date",
+                "Merchant": "description",
+                "Category": "primary_category",
+                "Amount": "amount",
+            },
+        )
+        plan = planner.plan(["Txn Date", "Merchant", "Category", "Amount"], [])
+        assert plan.column_map["Txn Date"] == "authorized_date"
+        assert plan.column_map["Amount"] == "amount"
+
+    def test_category_map_built_from_cache(self):
+        planner = _make_planner(
+            col_rules={
+                "Date": "authorized_date",
+                "Desc": "description",
+                "Cat": "primary_category",
+                "Amt": "amount",
+            },
+            cat_rules={
+                "Dining Out": {"primary": "Food & drink", "detailed": "Restaurants & bars"},
+            },
+        )
+        plan = planner.plan(["Date", "Desc", "Cat", "Amt"], ["Dining Out"])
+        assert isinstance(plan.category_map["Dining Out"], CategoryMapping)
+        assert plan.category_map["Dining Out"].primary == "Food & drink"
+
+
+# ── Partial cache hit ──────────────────────────────────────────────────────────
+
+class TestPartialCacheHit:
+    """Some items cached, others need AI."""
+
+    def test_only_uncached_headers_sent_to_ai(self):
+        planner = _make_planner(
+            col_rules={"Txn Date": "authorized_date"},  # one header cached
+            ai_plan=_make_ai_plan(
+                column_map={
+                    "Merchant": "description",
+                    "Category": "primary_category",
+                    "Amount": "amount",
+                }
+            ),
+        )
+        planner.plan(["Txn Date", "Merchant", "Category", "Amount"], [])
+
+        ai_headers = planner._ai.plan_csv.call_args[0][0]
+        assert "Txn Date" not in ai_headers
+        assert "Merchant" in ai_headers
+
+    def test_only_uncached_categories_sent_to_ai(self):
+        planner = _make_planner(
+            col_rules={
+                "Date": "authorized_date",
+                "Desc": "description",
+                "Cat": "primary_category",
+                "Amt": "amount",
+            },
+            cat_rules={"Gas": {"primary": "Transportation", "detailed": "Gas & EV charging"}},
+            ai_plan=_make_ai_plan(
+                category_map={
+                    "Dining Out": CategoryMapping(primary="Food & drink", detailed="Restaurants & bars")
+                }
+            ),
+        )
+        planner.plan(["Date", "Desc", "Cat", "Amt"], ["Gas", "Dining Out"])
+
+        ai_categories = planner._ai.plan_csv.call_args[0][1]
+        assert "Gas" not in ai_categories
+        assert "Dining Out" in ai_categories
+
+    def test_cache_and_ai_merged_into_single_plan(self):
+        planner = _make_planner(
+            col_rules={"Txn Date": "authorized_date"},
+            ai_plan=_make_ai_plan(
+                column_map={
+                    "Merchant": "description",
+                    "Category": "primary_category",
+                    "Amount": "amount",
+                }
+            ),
+        )
+        plan = planner.plan(["Txn Date", "Merchant", "Category", "Amount"], [])
+        assert plan.column_map["Txn Date"] == "authorized_date"
+        assert plan.column_map["Merchant"] == "description"
+        assert plan.column_map["Amount"] == "amount"
+
+
+# ── Missing required columns ───────────────────────────────────────────────────
+
+class TestMissingRequiredColumns:
+    def test_missing_primary_category_in_unmapped_required(self):
+        # No header maps to primary_category, AI also returns nothing for it
+        planner = _make_planner(
+            ai_plan=_make_ai_plan(
+                column_map={
+                    "Date": "authorized_date",
+                    "Desc": "description",
+                    "Amt": "amount",
+                    # no primary_category mapping
+                }
+            ),
+        )
+        plan = planner.plan(["Date", "Desc", "Amt"], [])
+        assert "primary_category" in plan.unmapped_required_columns
+
+    def test_all_required_mapped_means_no_unmapped_required(self):
+        planner = _make_planner(
+            ai_plan=_make_ai_plan(
+                column_map={
+                    "Date": "authorized_date",
+                    "Desc": "description",
+                    "Cat": "primary_category",
+                    "Amt": "amount",
+                }
+            ),
+        )
+        plan = planner.plan(["Date", "Desc", "Cat", "Amt"], [])
+        assert plan.unmapped_required_columns == []
+
+    def test_multiple_unmapped_required_fields_listed(self):
+        planner = _make_planner(
+            ai_plan=_make_ai_plan(
+                column_map={"Date": "authorized_date"},  # only date mapped
+                unmapped_required_columns=["description", "primary_category", "amount"],
+            ),
+        )
+        plan = planner.plan(["Date", "Unknown1", "Unknown2"], [])
+        assert "description" in plan.unmapped_required_columns
+        assert "primary_category" in plan.unmapped_required_columns
+        assert "amount" in plan.unmapped_required_columns
+
+
+# ── Debit/credit detection ─────────────────────────────────────────────────────
+
+class TestDebitCreditDetection:
+    def test_debit_credit_headers_trigger_ai_call(self):
+        planner = _make_planner(
+            ai_plan=_make_ai_plan(
+                column_map={
+                    "Date": "authorized_date",
+                    "Desc": "description",
+                    "Cat": "primary_category",
+                },
+                amount_transform=AmountTransform.DEBIT_CREDIT,
+                debit_column="Debit",
+                credit_column="Credit",
+            ),
+        )
+        planner.plan(["Date", "Desc", "Cat", "Debit", "Credit"], [])
+        planner._ai.plan_csv.assert_called_once()
+
+    def test_amount_transform_set_to_debit_credit(self):
+        planner = _make_planner(
+            ai_plan=_make_ai_plan(
+                column_map={
+                    "Date": "authorized_date",
+                    "Desc": "description",
+                    "Cat": "primary_category",
+                },
+                amount_transform=AmountTransform.DEBIT_CREDIT,
+                debit_column="Debit",
+                credit_column="Credit",
+            ),
+        )
+        plan = planner.plan(["Date", "Desc", "Cat", "Debit", "Credit"], [])
+        assert plan.amount_transform == AmountTransform.DEBIT_CREDIT
+        assert plan.debit_column == "Debit"
+        assert plan.credit_column == "Credit"


### PR DESCRIPTION
Closes #37

Adds the CSVNormalizationPlanner to csv ingenstion pipeline. Pulls from cached rule sets to limit token usage and reduce LLM normalizaiton error.