### PR TITLE
feat: import endpoint accepts normalization_plan + saves rules (#39)

### DIFF
--- a/backend/api/transactions/transactions_models.py
+++ b/backend/api/transactions/transactions_models.py
@@ -171,5 +171,7 @@ class ImportJobStatus(BaseModel):
     rows_imported: Optional[int] = None
     rows_updated: Optional[int] = None
     errors: Optional[str] = None
+    rules_applied_from_cache: Optional[int] = None
+    new_rules_saved: Optional[int] = None  # See note in UploadJobsTable.new_rules_saved
 
     model_config = outgoing_config

--- a/backend/api/transactions/transactions_router.py
+++ b/backend/api/transactions/transactions_router.py
@@ -8,6 +8,8 @@ with optional filters/pagination and CSV import with async job tracking.
 Functions:
 """
 # Standard library imports
+import csv as csv_lib
+import io
 import json as json_lib
 from pleasant_loggers import get_logger
 import os
@@ -16,7 +18,7 @@ from typing import Optional
 
 # Third party imports
 import pandas as pd
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Request, UploadFile
 from uuid import uuid4
 
 logger = get_logger(__name__)
@@ -25,6 +27,8 @@ logger = get_logger(__name__)
 from pleasant_database import DatabaseFile
 
 # Local imports
+from backend.ai_modules.csv_transform_applicator import TransformValidationError, apply_normalization_plan
+from backend.ai_modules.normalization_plan import NormalizationPlan
 from backend.api.transactions.transactions_models import (
     BulkUpdateRequest,
     Transaction,
@@ -230,25 +234,91 @@ async def update_transaction(
 
 # ─── CSV Import Endpoints ─────────────────────────────────────────────────────
 
-def _process_csv_upload(job_id: str, tmp_path: str) -> None:
+def _process_csv_upload(
+    job_id: str,
+    tmp_path: str,
+    normalization_plan_json: Optional[str] = None,
+) -> None:
     """
     Background task: uploads a CSV file to the transactions table using the existing
-    upload_csv() pipeline. Updates job status throughout and cleans up the temp file.
+    upload_csv() pipeline. When normalization_plan_json is provided, applies
+    CSVTransformApplicator before validation and saves approved rules afterward.
 
     Creates its own DB session — background tasks must not reuse the request session.
     """
     db_file = DatabaseFile(EDirectories.DB_FILENAME, EDirectories.DB_DIR)
     session = DatabaseSession(db_file)
+    transformed_tmp: Optional[str] = None
 
     try:
         session.jobs.set_status(job_id, "processing")
 
+        rules_applied_from_cache = 0
+        new_rules_saved = 0
+        plan: Optional[NormalizationPlan] = None
+
+        if normalization_plan_json:
+            plan = NormalizationPlan.model_validate_json(normalization_plan_json)
+
+            if plan.unmapped_required_columns:
+                session.jobs.set_status(
+                    job_id, "failed",
+                    errors=f"Required columns not mapped: {plan.unmapped_required_columns}",
+                )
+                return
+
+            with open(tmp_path, newline="", encoding="utf-8") as f:
+                reader = csv_lib.DictReader(f)
+                raw_rows = list(reader)
+
+            try:
+                transformed_rows = apply_normalization_plan(raw_rows, plan)
+            except TransformValidationError as e:
+                session.jobs.set_status(job_id, "failed", errors=str(e))
+                return
+
+            # Write transformed rows to a new temp CSV for upload_csv()
+            all_fields = list(dict.fromkeys(k for row in transformed_rows for k in row))
+            transformed_tmp = f"{tmp_path}_transformed.csv"
+            with open(transformed_tmp, "w", newline="", encoding="utf-8") as f:
+                writer = csv_lib.DictWriter(f, fieldnames=all_fields)
+                writer.writeheader()
+                writer.writerows(transformed_rows)
+
+            upload_path = transformed_tmp
+
+            # Count rules before saving (exact per-mapping check)
+            for raw_val, mapped_col in plan.column_map.items():
+                if mapped_col:
+                    if session.category_mapping_rules.get_column_rule(raw_val):
+                        rules_applied_from_cache += 1
+                    else:
+                        new_rules_saved += 1
+            for raw_cat in plan.category_map:
+                if session.category_mapping_rules.get_category_rule(raw_cat):
+                    rules_applied_from_cache += 1
+                else:
+                    new_rules_saved += 1
+        else:
+            upload_path = tmp_path
+
         count_before = session.transactions.count_items()
-        updated_records = session.transactions.upload_csv(tmp_path)
+        updated_records = session.transactions.upload_csv(upload_path)
         count_after = session.transactions.count_items()
 
         rows_imported = count_after - count_before
         rows_updated = len(updated_records)
+
+        if plan:
+            # Save new rules after successful import
+            for raw_val, mapped_col in plan.column_map.items():
+                if mapped_col and not session.category_mapping_rules.get_column_rule(raw_val):
+                    session.category_mapping_rules.upsert_column_rule(raw_val, mapped_col)
+            for raw_cat, mapping in plan.category_map.items():
+                if not session.category_mapping_rules.get_category_rule(raw_cat):
+                    session.category_mapping_rules.upsert_category_rule(
+                        raw_cat, mapping.primary, mapping.detailed
+                    )
 
         session.rules.apply_rules_to_all(session.transactions)
 
@@ -276,6 +346,8 @@ def _process_csv_upload(job_id: str, tmp_path: str) -> None:
             job_id, "complete",
             rows_imported=rows_imported,
             rows_updated=rows_updated,
+            rules_applied_from_cache=rules_applied_from_cache,
+            new_rules_saved=new_rules_saved,
         )
 
     except Exception as e:
@@ -284,6 +356,8 @@ def _process_csv_upload(job_id: str, tmp_path: str) -> None:
     finally:
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
+        if transformed_tmp and os.path.exists(transformed_tmp):
+            os.remove(transformed_tmp)
         session.close()
 
 
@@ -291,10 +365,15 @@ def _process_csv_upload(job_id: str, tmp_path: str) -> None:
 async def import_transactions_csv(
     background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
+    normalization_plan: Optional[str] = Form(None),
 ) -> UploadJobResponse:
     """
     Accepts a CSV file upload, saves it to a temp path, creates a job record,
     and queues a background task to process it. Returns a job_id immediately.
+
+    normalization_plan: optional JSON-encoded NormalizationPlan from POST /ai/plan-csv.
+    When provided, CSVTransformApplicator runs before existing validation and approved
+    rules are saved to CategoryMappingRulesManager after successful import.
     """
     tmp_path = f"/tmp/{uuid4()}_{file.filename}"
     contents = await file.read()
@@ -311,7 +390,7 @@ async def import_transactions_csv(
     job_id = jobs_session.jobs.create_job(tmp_path)
     jobs_session.close()
 
-    background_tasks.add_task(_process_csv_upload, job_id, tmp_path)
+    background_tasks.add_task(_process_csv_upload, job_id, tmp_path, normalization_plan)
 
     return {"job_id": job_id, "status": "pending"}
 
@@ -333,6 +412,8 @@ async def get_import_job_status(job_id: str) -> ImportJobStatus:
         "rows_imported": job.rows_imported,
         "rows_updated": job.rows_updated,
         "errors": job.errors,
+        "rules_applied_from_cache": job.rules_applied_from_cache,
+        "new_rules_saved": job.new_rules_saved,
     }
 
 
@@ -445,4 +526,6 @@ async def confirm_import_job(job_id: str) -> ImportJobStatus:
         "rows_imported": job.rows_imported,
         "rows_updated": job.rows_updated,
         "errors": job.errors,
+        "rules_applied_from_cache": job.rules_applied_from_cache,
+        "new_rules_saved": job.new_rules_saved,
     }

--- a/backend/database_modules/models/transactions.py
+++ b/backend/database_modules/models/transactions.py
@@ -101,6 +101,12 @@ class UploadJobsTable(BaseTable):
         - rows_imported: Integer (nullable) — new rows added to transactions table
         - rows_updated: Integer (nullable) — rows whose categories were updated
         - errors: String (nullable) — error message if processing failed
+        - rules_applied_from_cache: Integer (nullable) — mappings resolved from rules cache
+        - new_rules_saved: Integer (nullable) — new mappings saved after import approval
+          NOTE: In a future multi-user system, rules will be shared globally across users.
+          In that context this field is less meaningful (saving a rule benefits all users,
+          not just the importer). To remove: drop this column, ImportJobStatus.new_rules_saved,
+          and the counting logic in _process_csv_upload.
         - created_at: DateTime
     """
 
@@ -113,6 +119,8 @@ class UploadJobsTable(BaseTable):
     rows_imported = Column(Integer, nullable=True)
     rows_updated = Column(Integer, nullable=True)
     errors = Column(String, nullable=True)
+    rules_applied_from_cache = Column(Integer, nullable=True)
+    new_rules_saved = Column(Integer, nullable=True)
     created_at = Column(DateTime)
 
 

--- a/backend/tests/test_api_import_with_plan.py
+++ b/backend/tests/test_api_import_with_plan.py
@@ -1,0 +1,370 @@
+#!python3
+"""
+Tests for the updated POST /transactions/import endpoint (issue #39).
+
+Covers:
+- Endpoint accepts optional normalization_plan form field
+- _process_csv_upload applies CSVTransformApplicator when plan is provided
+- Job fails when unmapped required columns remain in the plan
+- Job fails when TransformValidationError is raised by the applicator
+- Rules are saved to CategoryMappingRulesManager after successful import with plan
+- rules_applied_from_cache and new_rules_saved counted correctly
+- Existing import flow (no plan) is unaffected
+- ImportJobStatus response includes the new rule count fields
+"""
+import io
+import json
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.ai_modules.csv_transform_applicator import TransformValidationError
+from backend.ai_modules.normalization_plan import AmountTransform, CategoryMapping, NormalizationPlan
+from backend.api.transactions.transactions_router import _process_csv_upload
+from backend.main import app
+
+client = TestClient(app)
+
+# ── Fixtures and helpers ──────────────────────────────────────────────────────
+
+BUDGY_CSV = (
+    "authorized_date,description,primary_category,amount\n"
+    "2024-01-01,Coffee,Food & drink,-5.00\n"
+    "2024-01-02,Gas,Transportation,-40.00\n"
+)
+
+MESSY_CSV = (
+    "Date,Merchant,Category,Amt\n"
+    "2024-01-01,Coffee Shop,Dining,-5.00\n"
+    "2024-01-02,Gas Station,Transport,-40.00\n"
+)
+
+
+def _make_plan(**kwargs) -> NormalizationPlan:
+    defaults = dict(
+        column_map={
+            "Date": "authorized_date",
+            "Merchant": "description",
+            "Category": "primary_category",
+            "Amt": "amount",
+        },
+        category_map={
+            "Dining": CategoryMapping(primary="Food & drink", detailed="Restaurants & bars"),
+            "Transport": CategoryMapping(primary="Transportation", detailed="Gas & EV charging"),
+        },
+        amount_transform=AmountTransform.SIGNED,
+        debit_column=None,
+        credit_column=None,
+        issues=[],
+        unmapped_required_columns=[],
+    )
+    defaults.update(kwargs)
+    return NormalizationPlan(**defaults)
+
+
+def _make_session_mock(
+    col_rule_exists: bool = False,
+    cat_rule_exists: bool = False,
+) -> MagicMock:
+    """Returns a mock DatabaseSession with enough surface for _process_csv_upload."""
+    session = MagicMock()
+    session.category_mapping_rules.get_column_rule.return_value = "existing" if col_rule_exists else None
+    session.category_mapping_rules.get_category_rule.return_value = {"primary": "x", "detailed": "y"} if cat_rule_exists else None
+    session.transactions.count_items.return_value = 0
+    session.transactions.upload_csv.return_value = []
+    session.transactions.to_dataframe.return_value = __import__("pandas").DataFrame()
+    return session
+
+
+# ── Unit tests for _process_csv_upload ───────────────────────────────────────
+
+class TestProcessCSVUploadNoPlan:
+    def test_upload_csv_called_with_original_path(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(BUDGY_CSV)
+        session = _make_session_mock()
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value.__enter__ = MagicMock(return_value=session)
+            MockSession.return_value = session
+
+            _process_csv_upload("job-1", str(csv_file))
+
+        session.transactions.upload_csv.assert_called_once_with(str(csv_file))
+
+    def test_job_set_to_complete(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(BUDGY_CSV)
+        session = _make_session_mock()
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file))
+
+        status_calls = [c[0][1] for c in session.jobs.set_status.call_args_list]
+        assert "complete" in status_calls
+
+    def test_rule_counts_zero_without_plan(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(BUDGY_CSV)
+        session = _make_session_mock()
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file))
+
+        complete_call = next(
+            c for c in session.jobs.set_status.call_args_list if c[0][1] == "complete"
+        )
+        assert complete_call[1].get("rules_applied_from_cache") == 0
+        assert complete_call[1].get("new_rules_saved") == 0
+
+
+class TestProcessCSVUploadWithPlan:
+    def test_transform_applied_before_upload(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan()
+        session = _make_session_mock()
+
+        transformed_rows = [
+            {"authorized_date": "2024-01-01", "description": "Coffee Shop", "primary_category": "Food & drink", "amount": -5.0},
+            {"authorized_date": "2024-01-02", "description": "Gas Station", "primary_category": "Transportation", "amount": -40.0},
+        ]
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"), \
+             patch("backend.api.transactions.transactions_router.apply_normalization_plan", return_value=transformed_rows) as mock_apply:
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        mock_apply.assert_called_once()
+        # upload_csv should be called with the transformed temp file, not original
+        upload_path = session.transactions.upload_csv.call_args[0][0]
+        assert upload_path != str(csv_file)
+        assert "_transformed.csv" in upload_path
+
+    def test_job_fails_when_unmapped_required_columns(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan(unmapped_required_columns=["primary_category"])
+        session = _make_session_mock()
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        status_calls = {c[0][1]: c for c in session.jobs.set_status.call_args_list}
+        assert "failed" in status_calls
+        error_msg = status_calls["failed"][1].get("errors", "")
+        assert "primary_category" in error_msg
+        session.transactions.upload_csv.assert_not_called()
+
+    def test_job_fails_on_transform_validation_error(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan()
+        session = _make_session_mock()
+
+        failed_rows = [{"row_index": 0, "missing_fields": ["amount"]}]
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"), \
+             patch("backend.api.transactions.transactions_router.apply_normalization_plan",
+                   side_effect=TransformValidationError(failed_rows)):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        status_calls = {c[0][1]: c for c in session.jobs.set_status.call_args_list}
+        assert "failed" in status_calls
+        session.transactions.upload_csv.assert_not_called()
+
+    def test_new_rules_saved_after_import(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan()
+        session = _make_session_mock(col_rule_exists=False, cat_rule_exists=False)
+
+        transformed_rows = [
+            {"authorized_date": "2024-01-01", "description": "Coffee Shop",
+             "primary_category": "Food & drink", "amount": -5.0},
+        ]
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"), \
+             patch("backend.api.transactions.transactions_router.apply_normalization_plan",
+                   return_value=transformed_rows):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        session.category_mapping_rules.upsert_column_rule.assert_called()
+        session.category_mapping_rules.upsert_category_rule.assert_called()
+
+    def test_cached_rules_not_re_saved(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan()
+        # All rules already exist in cache
+        session = _make_session_mock(col_rule_exists=True, cat_rule_exists=True)
+
+        transformed_rows = [
+            {"authorized_date": "2024-01-01", "description": "Coffee Shop",
+             "primary_category": "Food & drink", "amount": -5.0},
+        ]
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"), \
+             patch("backend.api.transactions.transactions_router.apply_normalization_plan",
+                   return_value=transformed_rows):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        session.category_mapping_rules.upsert_column_rule.assert_not_called()
+        session.category_mapping_rules.upsert_category_rule.assert_not_called()
+
+    def test_rules_applied_from_cache_counted(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan()
+        # All rules exist in cache
+        session = _make_session_mock(col_rule_exists=True, cat_rule_exists=True)
+
+        transformed_rows = [{"authorized_date": "2024-01-01", "description": "x",
+                              "primary_category": "Food & drink", "amount": -5.0}]
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"), \
+             patch("backend.api.transactions.transactions_router.apply_normalization_plan",
+                   return_value=transformed_rows):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        complete_call = next(
+            c for c in session.jobs.set_status.call_args_list if c[0][1] == "complete"
+        )
+        # 4 column mappings + 2 category mappings, all cached
+        assert complete_call[1]["rules_applied_from_cache"] == 6
+        assert complete_call[1]["new_rules_saved"] == 0
+
+    def test_new_rules_saved_counted(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan()
+        # No rules in cache
+        session = _make_session_mock(col_rule_exists=False, cat_rule_exists=False)
+
+        transformed_rows = [{"authorized_date": "2024-01-01", "description": "x",
+                              "primary_category": "Food & drink", "amount": -5.0}]
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"), \
+             patch("backend.api.transactions.transactions_router.apply_normalization_plan",
+                   return_value=transformed_rows):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        complete_call = next(
+            c for c in session.jobs.set_status.call_args_list if c[0][1] == "complete"
+        )
+        # 4 column mappings + 2 category mappings, all new
+        assert complete_call[1]["new_rules_saved"] == 6
+        assert complete_call[1]["rules_applied_from_cache"] == 0
+
+    def test_transformed_temp_file_cleaned_up(self, tmp_path):
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text(MESSY_CSV)
+        plan = _make_plan()
+        session = _make_session_mock()
+
+        transformed_rows = [{"authorized_date": "2024-01-01", "description": "x",
+                              "primary_category": "Food & drink", "amount": -5.0}]
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"), \
+             patch("backend.api.transactions.transactions_router.apply_normalization_plan",
+                   return_value=transformed_rows):
+            MockSession.return_value = session
+            _process_csv_upload("job-1", str(csv_file), plan.model_dump_json())
+
+        # The original file should be cleaned up (we're using tmp_path so it persists, but
+        # the test verifies no exception was raised and job completed successfully)
+        complete_calls = [c for c in session.jobs.set_status.call_args_list if c[0][1] == "complete"]
+        assert len(complete_calls) == 1
+
+
+# ── Endpoint-level tests ──────────────────────────────────────────────────────
+
+class TestImportEndpointWithPlan:
+    def test_endpoint_accepts_normalization_plan_field(self):
+        plan = _make_plan()
+        plan_json = plan.model_dump_json()
+
+        with patch("backend.api.transactions.transactions_router._process_csv_upload") as mock_task, \
+             patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value.jobs.create_job.return_value = "test-job-id"
+            response = client.post(
+                "/transactions/import",
+                files={"file": ("test.csv", io.BytesIO(MESSY_CSV.encode()), "text/csv")},
+                data={"normalization_plan": plan_json},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["jobId"] == "test-job-id"
+
+    def test_endpoint_passes_plan_to_background_task(self):
+        plan = _make_plan()
+        plan_json = plan.model_dump_json()
+
+        with patch("backend.api.transactions.transactions_router._process_csv_upload") as mock_task, \
+             patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value.jobs.create_job.return_value = "test-job-id"
+            client.post(
+                "/transactions/import",
+                files={"file": ("test.csv", io.BytesIO(MESSY_CSV.encode()), "text/csv")},
+                data={"normalization_plan": plan_json},
+            )
+
+        # The background task is queued via BackgroundTasks, not called directly,
+        # so we verify the response status and job creation instead.
+        MockSession.return_value.jobs.create_job.assert_called_once()
+
+    def test_endpoint_works_without_plan(self):
+        with patch("backend.api.transactions.transactions_router._process_csv_upload"), \
+             patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value.jobs.create_job.return_value = "test-job-id"
+            response = client.post(
+                "/transactions/import",
+                files={"file": ("test.csv", io.BytesIO(BUDGY_CSV.encode()), "text/csv")},
+            )
+
+        assert response.status_code == 200
+
+
+class TestImportJobStatusFields:
+    def test_get_job_status_includes_rule_counts(self):
+        mock_job = MagicMock()
+        mock_job.job_id = "job-123"
+        mock_job.status = "complete"
+        mock_job.rows_imported = 10
+        mock_job.rows_updated = 2
+        mock_job.errors = None
+        mock_job.rules_applied_from_cache = 5
+        mock_job.new_rules_saved = 3
+
+        with patch("backend.api.transactions.transactions_router.DatabaseSession") as MockSession, \
+             patch("backend.api.transactions.transactions_router.DatabaseFile"):
+            MockSession.return_value.jobs.get_job.return_value = mock_job
+            response = client.get("/transactions/import/job-123")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["rulesAppliedFromCache"] == 5
+        assert data["newRulesSaved"] == 3


### PR DESCRIPTION
Closes #39

## Summary
- `POST /transactions/import` now accepts an optional `normalization_plan` multipart form field (JSON-encoded `NormalizationPlan`)
- When provided: `CSVTransformApplicator` runs on raw rows → transformed rows written to temp CSV → passed to existing `upload_csv()` pipeline
- After successful import: new column/category rules saved to `CategoryMappingRulesManager`; cached rules counted but not re-saved
- `ImportJobStatus` extended with `rules_applied_from_cache` and `new_rules_saved`; `UploadJobsTable` gains matching nullable columns
- Existing flow (no plan) is fully backwards-compatible

## Test plan
- [x] `pytest` — 334 tests pass
- [x] Import with plan → rows transformed, rules saved, counts in job status
- [x] Import with plan containing unmapped required columns → job fails with clear error
- [x] Import without plan → existing behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)