### PR TITLE
feat: fetchWithRetry utility and planCSV response validation

### DIFF
--- a/frontend/src/__tests__/planCSV.test.ts
+++ b/frontend/src/__tests__/planCSV.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchWithRetry } from "../api/utils";
+import { planCSV } from "../api/ai";
+
+// ─── fetchWithRetry ───────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Speed up backoff delays in tests
+vi.useFakeTimers();
+
+afterEach(() => {
+  mockFetch.mockReset();
+  vi.clearAllTimers();
+});
+
+function response(status: number, body = {}): Response {
+  return { ok: status < 400, status, json: async () => body } as unknown as Response;
+}
+
+describe("fetchWithRetry", () => {
+  it("returns immediately on success", async () => {
+    mockFetch.mockResolvedValueOnce(response(200));
+    const res = await fetchWithRetry("/url");
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on 500 and succeeds on second attempt", async () => {
+    mockFetch
+      .mockResolvedValueOnce(response(500))
+      .mockResolvedValueOnce(response(200));
+
+    const promise = fetchWithRetry("/url");
+    await vi.runAllTimersAsync();
+    const res = await promise;
+
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on 400", async () => {
+    mockFetch.mockResolvedValueOnce(response(400));
+    const res = await fetchWithRetry("/url");
+    expect(res.status).toBe(400);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on network error and succeeds on second attempt", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error("network failure"))
+      .mockResolvedValueOnce(response(200));
+
+    const promise = fetchWithRetry("/url");
+    await vi.runAllTimersAsync();
+    const res = await promise;
+
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after exhausting all retries on persistent 500", async () => {
+    mockFetch.mockResolvedValue(response(500));
+
+    const promise = fetchWithRetry("/url", undefined, 2);
+    await vi.runAllTimersAsync();
+
+    // Third call returns 500 and no more retries remain — returns the 500 response
+    const res = await promise;
+    expect(res.status).toBe(500);
+    expect(mockFetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("throws after exhausting all retries on persistent network error", async () => {
+    mockFetch.mockRejectedValue(new Error("network failure"));
+
+    const promise = fetchWithRetry("/url", undefined, 2);
+    // Attach handler before running timers to prevent an unhandled rejection warning
+    const rejectExpect = expect(promise).rejects.toThrow("network failure");
+    await vi.runAllTimersAsync();
+    await rejectExpect;
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ─── planCSV response shape validation ───────────────────────────────────────
+
+const VALID_PLAN = {
+  column_map: {},
+  category_map: {},
+  amount_transform: "signed",
+  issues: [],
+  unmapped_required_columns: [],
+  debit_column: null,
+  credit_column: null,
+  used_cache: false,
+  requires_manual_review: false,
+};
+
+// planCSV reads isMock() from the store — keep it in real mode
+vi.mock("../store/mockMode", () => ({
+  useMockMode: { getState: () => ({ isMockMode: false }) },
+}));
+
+describe("planCSV shape validation", () => {
+  it("resolves with a valid plan", async () => {
+    mockFetch.mockResolvedValueOnce(response(200, VALID_PLAN));
+    const plan = await planCSV(new File(["a,b"], "test.csv"));
+    expect(plan.column_map).toEqual({});
+  });
+
+  it("throws a descriptive error when required fields are missing", async () => {
+    const incomplete = { column_map: {}, category_map: {} }; // missing amount_transform, issues, unmapped_required_columns
+    mockFetch.mockResolvedValueOnce(response(200, incomplete));
+    await expect(planCSV(new File(["a,b"], "test.csv"))).rejects.toThrow("unexpected response");
+  });
+
+  it("throws when the response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 422, json: async () => ({ detail: "Bad file" }) } as unknown as Response);
+    await expect(planCSV(new File(["a,b"], "test.csv"))).rejects.toThrow("Bad file");
+  });
+});

--- a/frontend/src/api/ai.ts
+++ b/frontend/src/api/ai.ts
@@ -1,6 +1,15 @@
 import type { AISummary, NormalizationPlan } from "../types";
 import { mockAISummary } from "../__tests__/fixtures";
 import { useMockMode } from "../store/mockMode";
+import { fetchWithRetry } from "./utils";
+
+const PLAN_REQUIRED_FIELDS = [
+  "column_map",
+  "category_map",
+  "amount_transform",
+  "issues",
+  "unmapped_required_columns",
+] as const;
 
 const isMock = () => useMockMode.getState().isMockMode;
 
@@ -41,7 +50,7 @@ export async function planCSV(file: File): Promise<NormalizationPlan> {
 
   const formData = new FormData();
   formData.append("file", file);
-  const res = await fetch("/api/ai/plan-csv", { method: "POST", body: formData });
+  const res = await fetchWithRetry("/api/ai/plan-csv", { method: "POST", body: formData });
   if (!res.ok) {
     let detail = `Analysis failed (${res.status})`;
     try {
@@ -50,5 +59,10 @@ export async function planCSV(file: File): Promise<NormalizationPlan> {
     } catch { /* ignore parse errors */ }
     throw new Error(detail);
   }
-  return res.json() as Promise<NormalizationPlan>;
+  const plan = await res.json();
+  const missing = PLAN_REQUIRED_FIELDS.filter((f) => !(f in plan));
+  if (missing.length > 0) {
+    throw new Error(`Analysis returned an unexpected response (missing: ${missing.join(", ")}). Please try again.`);
+  }
+  return plan as NormalizationPlan;
 }

--- a/frontend/src/api/utils.ts
+++ b/frontend/src/api/utils.ts
@@ -1,0 +1,26 @@
+/** Retries a fetch on network errors and 5xx responses. Never retries on 4xx. */
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  maxRetries = 2,
+): Promise<Response> {
+  let delay = 500;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let res: Response;
+    try {
+      res = await fetch(input, init);
+    } catch (err) {
+      if (attempt === maxRetries) throw err;
+      await new Promise((r) => setTimeout(r, delay));
+      delay *= 2;
+      continue;
+    }
+    if (res.status >= 500 && attempt < maxRetries) {
+      await new Promise((r) => setTimeout(r, delay));
+      delay *= 2;
+      continue;
+    }
+    return res;
+  }
+  throw new Error("fetchWithRetry: exhausted retries");
+}


### PR DESCRIPTION
Closes #47

## Summary
- New `fetchWithRetry` helper in `src/api/utils.ts` — retries on network errors and 5xx only, 2 retries max, exponential backoff 500ms → 1000ms
- `planCSV` uses `fetchWithRetry` instead of bare `fetch`
- `planCSV` validates response shape and throws a descriptive error if any required field is missing

## Test plan
- [x] `fetchWithRetry` retries on 500, does not retry on 400, succeeds on second attempt
- [x] `planCSV` throws on missing response fields
- [x] All 9 unit tests in `src/__tests__/planCSV.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)