### PR TITLE
Fix flagged-transaction status resolution and add specific flag messaging

### DIFF
--- a/backend/api/transactions/transactions_router.py
+++ b/backend/api/transactions/transactions_router.py
@@ -44,6 +44,7 @@ from backend.api.transactions.transactions_models import (
 )
 from backend.database_modules.db_session import DatabaseSession
 from backend.database_modules.models.transactions import TransactionsTable
+from backend.utils.analysis_utils import DetailedCategories, PrimaryCategories
 from backend.utils.api_utils import RouterPrefixes
 from backend.utils.file_utils import EDirectories
 
@@ -54,6 +55,30 @@ SORT_BY_COLUMN = {
     "date": TransactionsTable.authorized_date.name,
     "amount": TransactionsTable.amount.name,
 }
+
+# Required for a transaction to be considered "Verified" rather than "Unchecked"
+_REQUIRED_FOR_VERIFY = (
+    TransactionsTable.description.name,
+    TransactionsTable.amount.name,
+    TransactionsTable.authorized_date.name,
+    TransactionsTable.primary_category.name,
+    TransactionsTable.detailed_category.name,
+)
+
+
+def _resolve_status(row: dict) -> str:
+    """
+    Determines whether a transaction row should be "Verified" or "Unchecked":
+    Verified requires every required field to be populated AND the primary/detailed
+    category values to be recognised members of the category enums.
+    """
+    if any(row.get(field) in (None, "") for field in _REQUIRED_FOR_VERIFY):
+        return "Unchecked"
+    if row.get(TransactionsTable.primary_category.name) not in (e.value for e in PrimaryCategories):
+        return "Unchecked"
+    if row.get(TransactionsTable.detailed_category.name) not in (e.value for e in DetailedCategories):
+        return "Unchecked"
+    return "Verified"
 
 
 def get_db():
@@ -182,10 +207,20 @@ async def create_transaction(
     count = len(existing)
     uq_hash = hashlib.sha256(f"{base_hash}:{count}".encode()).hexdigest()
 
+    initial_status = _resolve_status(
+        {
+            TransactionsTable.description.name: body.description,
+            TransactionsTable.amount.name: body.amount,
+            TransactionsTable.authorized_date.name: authorized_date,
+            TransactionsTable.primary_category.name: body.primary_category,
+            TransactionsTable.detailed_category.name: body.detailed_category,
+        }
+    )
+
     db.transactions.add_item(
         **{
             TransactionsTable.authorized_date.name: authorized_date,
-            TransactionsTable.status.name: "Unchecked",
+            TransactionsTable.status.name: initial_status,
             TransactionsTable.account_name.name: body.account_name,
             TransactionsTable.description.name: body.description,
             TransactionsTable.primary_category.name: body.primary_category,
@@ -311,18 +346,14 @@ async def update_transaction(
 
     row = result.data.to_dict(orient="records")[0]
 
-    # Auto-promote: if the transaction was Unchecked and all required fields are now populated,
-    # set status to "Verified" so it drops off the flagged list automatically.
-    _REQUIRED_FOR_VERIFY = (
-        TransactionsTable.description.name,
-        TransactionsTable.amount.name,
-        TransactionsTable.authorized_date.name,
-        TransactionsTable.primary_category.name,
-        TransactionsTable.detailed_category.name,
-    )
-    if row.get(TransactionsTable.status.name) == "Unchecked" and all(row.get(f) not in (None, "") for f in _REQUIRED_FOR_VERIFY):
-        db.transactions.update_item(transaction_id, status="Verified")
-        row[TransactionsTable.status.name] = "Verified"
+    # Re-resolve status: a flagged transaction whose fields are now complete and valid is
+    # promoted to "Verified" so it drops off the flagged list automatically; one that still
+    # has missing/invalid fields stays "Unchecked" so its flag (and message) persists.
+    if row.get(TransactionsTable.status.name) == "Unchecked":
+        resolved_status = _resolve_status(row)
+        if resolved_status != row.get(TransactionsTable.status.name):
+            db.transactions.update_item(transaction_id, status=resolved_status)
+            row[TransactionsTable.status.name] = resolved_status
 
     return row
 

--- a/backend/tests/test_api/test_transactions/test_resolve_status.py
+++ b/backend/tests/test_api/test_transactions/test_resolve_status.py
@@ -1,0 +1,45 @@
+#!python3
+"""
+Pure unit tests for _resolve_status() — determines whether a transaction row
+should be considered "Verified" or remain "Unchecked" based on field completeness
+and category validity. No database, no HTTP client required.
+"""
+from datetime import datetime
+
+from backend.api.transactions.transactions_router import _resolve_status
+from backend.database_modules.models.transactions import TransactionsTable
+from backend.utils.analysis_utils import DetailedCategories, PrimaryCategories
+
+
+def make_row(**overrides) -> dict:
+    row = {
+        TransactionsTable.description.name: "Costco Wholesale",
+        TransactionsTable.amount.name: -143.27,
+        TransactionsTable.authorized_date.name: datetime(2024, 10, 15),
+        TransactionsTable.primary_category.name: PrimaryCategories.FOOD_AND_DRINK.value,
+        TransactionsTable.detailed_category.name: DetailedCategories.GROCERIES.value,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestResolveStatus:
+    def test_verified_when_all_fields_present_and_valid(self):
+        assert _resolve_status(make_row()) == "Verified"
+
+    def test_unchecked_when_description_missing(self):
+        assert _resolve_status(make_row(**{TransactionsTable.description.name: ""})) == "Unchecked"
+
+    def test_unchecked_when_amount_missing(self):
+        assert _resolve_status(make_row(**{TransactionsTable.amount.name: None})) == "Unchecked"
+
+    def test_unchecked_when_detailed_category_missing(self):
+        assert _resolve_status(make_row(**{TransactionsTable.detailed_category.name: None})) == "Unchecked"
+
+    def test_unchecked_when_primary_category_unrecognised(self):
+        row = make_row(**{TransactionsTable.primary_category.name: "Not a real category"})
+        assert _resolve_status(row) == "Unchecked"
+
+    def test_unchecked_when_detailed_category_unrecognised(self):
+        row = make_row(**{TransactionsTable.detailed_category.name: "Not a real detailed category"})
+        assert _resolve_status(row) == "Unchecked"

--- a/frontend/src/__tests__/transactionFlags.test.ts
+++ b/frontend/src/__tests__/transactionFlags.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { getFlagReasons } from "../lib/transactionFlags";
+import type { Transaction } from "../types";
+
+const categoryMapping: Record<string, string[]> = {
+  "Food & drink": ["Groceries", "Restaurants & bars"],
+  Shopping: ["Clothing & accessories", "Electronics"],
+};
+
+const baseTx = (overrides: Partial<Transaction> = {}): Transaction => ({
+  id: "1",
+  authorizedDate: "2024-10-15",
+  status: "Unchecked",
+  accountName: "Checking",
+  description: "Costco Wholesale",
+  primaryCategory: "Food & drink",
+  detailedCategory: "Groceries",
+  amount: -143.27,
+  repayment: false,
+  exclude: false,
+  ...overrides,
+});
+
+describe("getFlagReasons — missing fields", () => {
+  it("returns no reasons for a complete, valid transaction", () => {
+    expect(getFlagReasons(baseTx(), categoryMapping)).toEqual([]);
+  });
+
+  it("reports missing description", () => {
+    expect(getFlagReasons(baseTx({ description: "" }), categoryMapping)).toContain("Missing description");
+  });
+
+  it("reports missing amount", () => {
+    expect(getFlagReasons(baseTx({ amount: null as unknown as number }), categoryMapping)).toContain("Missing amount");
+  });
+
+  it("reports missing primary category", () => {
+    expect(getFlagReasons(baseTx({ primaryCategory: "" }), categoryMapping)).toContain("Missing primary category");
+  });
+
+  it("reports missing detailed category", () => {
+    expect(getFlagReasons(baseTx({ detailedCategory: "" }), categoryMapping)).toContain("Missing detailed category");
+  });
+});
+
+describe("getFlagReasons — unrecognised categories", () => {
+  it("reports an unrecognised primary category", () => {
+    const reasons = getFlagReasons(baseTx({ primaryCategory: "Food and drink" }), categoryMapping);
+    expect(reasons).toContain("Unrecognised primary category: 'Food and drink'");
+  });
+
+  it("reports an unrecognised detailed category", () => {
+    const reasons = getFlagReasons(baseTx({ detailedCategory: "Snacks" }), categoryMapping);
+    expect(reasons).toContain("Unrecognised detailed category: 'Snacks'");
+  });
+
+  it("does not report unrecognised reasons for empty fields (missing already covers it)", () => {
+    const reasons = getFlagReasons(baseTx({ primaryCategory: "" }), categoryMapping);
+    expect(reasons.some((r) => r.startsWith("Unrecognised"))).toBe(false);
+  });
+
+  it("skips category-validity checks when no mapping is supplied", () => {
+    const reasons = getFlagReasons(baseTx({ primaryCategory: "Food and drink" }));
+    expect(reasons).toEqual([]);
+  });
+});

--- a/frontend/src/components/dashboard/FlaggedTransactionsList.tsx
+++ b/frontend/src/components/dashboard/FlaggedTransactionsList.tsx
@@ -1,27 +1,10 @@
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useCategoryMapping } from "@/hooks/useCategories";
 import { formatCurrency, formatDate } from "@/lib/formatters";
+import { getFlagReasons } from "@/lib/transactionFlags";
 import type { Transaction } from "@/types";
 import { Flag } from "lucide-react";
-
-const MISSING_FIELD_LABELS: Record<string, string> = {
-  description: "description",
-  amount: "amount",
-  authorizedDate: "date",
-  primaryCategory: "category",
-  detailedCategory: "detailed category",
-};
-
-function getMissingFields(tx: Transaction): string[] {
-  const checks: Array<[string, boolean]> = [
-    ["description", !tx.description],
-    ["amount", tx.amount == null],
-    ["authorizedDate", !tx.authorizedDate],
-    ["primaryCategory", !tx.primaryCategory],
-    ["detailedCategory", !tx.detailedCategory],
-  ];
-  return checks.filter(([, missing]) => missing).map(([key]) => MISSING_FIELD_LABELS[key]);
-}
 
 interface FlaggedTransactionsListProps {
   transactions: Transaction[] | undefined;
@@ -41,8 +24,16 @@ function RowSkeleton() {
   );
 }
 
-function FlaggedRow({ tx, onEdit }: { tx: Transaction; onEdit: (tx: Transaction) => void }) {
-  const missing = getMissingFields(tx);
+function FlaggedRow({
+  tx,
+  onEdit,
+  categoryMapping,
+}: {
+  tx: Transaction;
+  onEdit: (tx: Transaction) => void;
+  categoryMapping?: Record<string, string[]>;
+}) {
+  const reasons = getFlagReasons(tx, categoryMapping);
   return (
     <button
       type="button"
@@ -52,8 +43,8 @@ function FlaggedRow({ tx, onEdit }: { tx: Transaction; onEdit: (tx: Transaction)
       <span className="text-xs text-muted-foreground w-24 shrink-0">{formatDate(tx.authorizedDate)}</span>
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium truncate">{tx.description || <span className="italic text-muted-foreground">No description</span>}</p>
-        {missing.length > 0 && (
-          <p className="text-xs text-amber-600 dark:text-amber-400">Missing: {missing.join(", ")}</p>
+        {reasons.length > 0 && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">{reasons.join(" · ")}</p>
         )}
       </div>
       <span className="text-sm font-medium tabular-nums text-red-600 dark:text-red-400 shrink-0">
@@ -70,6 +61,8 @@ export function FlaggedTransactionsList({
   isError,
   onEdit,
 }: FlaggedTransactionsListProps) {
+  const { data: categoryData } = useCategoryMapping();
+
   return (
     <div className="rounded-xl border border-border bg-card p-5">
       <div className="flex items-center gap-2 mb-4">
@@ -105,7 +98,7 @@ export function FlaggedTransactionsList({
       {!isLoading && !isError && transactions && transactions.length > 0 && (
         <div>
           {transactions.map((tx) => (
-            <FlaggedRow key={tx.id} tx={tx} onEdit={onEdit} />
+            <FlaggedRow key={tx.id} tx={tx} onEdit={onEdit} categoryMapping={categoryData?.categoryMapping} />
           ))}
         </div>
       )}

--- a/frontend/src/components/transactions/EditTransactionModal.tsx
+++ b/frontend/src/components/transactions/EditTransactionModal.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { useCategoryMapping } from "@/hooks/useCategories";
+import { getFlagReasons } from "@/lib/transactionFlags";
 import type { Transaction } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { X } from "lucide-react";
@@ -100,25 +101,6 @@ function InputClass(invalid: boolean) {
   return `w-full h-8 rounded-md border px-3 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${invalid ? "border-destructive" : "border-input"}`;
 }
 
-const MISSING_FIELD_LABELS: Record<string, string> = {
-  description: "Description",
-  amount: "Amount",
-  authorizedDate: "Date",
-  primaryCategory: "Category",
-  detailedCategory: "Detailed category",
-};
-
-function computeMissingFields(tx: Transaction): string[] {
-  const checks: Array<[string, boolean]> = [
-    ["description", !tx.description],
-    ["amount", tx.amount == null],
-    ["authorizedDate", !tx.authorizedDate],
-    ["primaryCategory", !tx.primaryCategory],
-    ["detailedCategory", !tx.detailedCategory],
-  ];
-  return checks.filter(([, missing]) => missing).map(([key]) => MISSING_FIELD_LABELS[key]);
-}
-
 function StatusBadge({ status }: { status: string }) {
   const isUnchecked = status === "Unchecked";
   return (
@@ -133,8 +115,6 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 export function EditTransactionModal({ transaction, isPending, availableTags, onSave, onClose, onDelete }: EditTransactionModalProps) {
-  const missingFields = computeMissingFields(transaction);
-
   const {
     register,
     handleSubmit,
@@ -162,6 +142,7 @@ export function EditTransactionModal({ transaction, isPending, availableTags, on
   const watchedPrimary = watch("primaryCategory");
   const watchedNotes = watch("notes") ?? "";
   const detailedOptions = (categoryData?.categoryMapping ?? {})[watchedPrimary] ?? [];
+  const flagReasons = getFlagReasons(transaction, categoryData?.categoryMapping);
 
   function onSubmit(values: FormValues) {
     onSave(transaction!.id, {
@@ -190,14 +171,14 @@ export function EditTransactionModal({ transaction, isPending, availableTags, on
           </button>
         </div>
 
-        {/* Missing fields banner */}
-        {missingFields.length > 0 && (
+        {/* Flag reasons banner */}
+        {flagReasons.length > 0 && (
           <div className="mx-5 mt-4 rounded-lg border border-yellow-400/40 bg-yellow-400/5 px-3 py-2.5">
             <p className="text-xs font-medium text-yellow-700 dark:text-yellow-400">
-              Missing required fields: {missingFields.join(", ")}
+              This transaction needs attention: {flagReasons.join("; ")}
             </p>
             <p className="text-xs text-yellow-600/80 dark:text-yellow-400/70 mt-0.5">
-              Fill in the fields above to clear this flag.
+              Fix the fields above and save to clear this flag.
             </p>
           </div>
         )}

--- a/frontend/src/lib/transactionFlags.ts
+++ b/frontend/src/lib/transactionFlags.ts
@@ -1,0 +1,42 @@
+import type { Transaction } from "@/types";
+
+const MISSING_FIELD_LABELS: Record<string, string> = {
+  description: "description",
+  amount: "amount",
+  authorizedDate: "date",
+  primaryCategory: "primary category",
+  detailedCategory: "detailed category",
+};
+
+/**
+ * Builds the list of human-readable reasons a transaction is flagged, distinguishing
+ * fields that are missing entirely from ones that hold an unrecognised category value
+ * (e.g. mismapped during CSV import). Used by both the flagged list and the edit modal
+ * so the messaging stays consistent.
+ */
+export function getFlagReasons(tx: Transaction, categoryMapping?: Record<string, string[]>): string[] {
+  const reasons: string[] = [];
+  const checks: Array<[keyof typeof MISSING_FIELD_LABELS, boolean]> = [
+    ["description", !tx.description],
+    ["amount", tx.amount == null],
+    ["authorizedDate", !tx.authorizedDate],
+    ["primaryCategory", !tx.primaryCategory],
+    ["detailedCategory", !tx.detailedCategory],
+  ];
+  for (const [key, missing] of checks) {
+    if (missing) reasons.push(`Missing ${MISSING_FIELD_LABELS[key]}`);
+  }
+
+  if (categoryMapping) {
+    const detailedCategories = Object.values(categoryMapping).flat();
+
+    if (tx.primaryCategory && !(tx.primaryCategory in categoryMapping)) {
+      reasons.push(`Unrecognised primary category: '${tx.primaryCategory}'`);
+    }
+    if (tx.detailedCategory && !detailedCategories.includes(tx.detailedCategory)) {
+      reasons.push(`Unrecognised detailed category: '${tx.detailedCategory}'`);
+    }
+  }
+
+  return reasons;
+}


### PR DESCRIPTION
## Summary
- Unify status resolution between `create_transaction` and `update_transaction` via a shared `_resolve_status` helper so transactions created/saved with complete, valid data are immediately `Verified` instead of incorrectly flagged
- Replace the generic "Unchecked" flag alert with specific, actionable reasons ("Missing description", "Unrecognised primary category: 'X'", etc.) in both the flagged list and the edit modal banner

Closes #70

## Test plan
- [x] Backend unit tests for `_resolve_status` (6 new, all passing)
- [x] Frontend unit tests for `getFlagReasons` (9 new, all passing)
- [x] Full backend suite passes (361 passed; excluded the unrelated, pre-existing CSV-pipeline AI-integration test)
- [x] Live browser verification in real-API mode: a transaction created via "Add Transaction" with valid data no longer appears flagged, and saving a flagged-but-valid transaction promotes it to Verified and removes it from the flagged list

🤖 Generated with [Claude Code](https://claude.com/claude-code)